### PR TITLE
Removed the unwanted condition for fetching lookups

### DIFF
--- a/dist/components/Grid/crud-helper.js
+++ b/dist/components/Grid/crud-helper.js
@@ -11,7 +11,6 @@ require("core-js/modules/es.array.sort.js");
 require("core-js/modules/es.json.stringify.js");
 require("core-js/modules/es.promise.js");
 require("core-js/modules/es.regexp.to-string.js");
-require("core-js/modules/es.string.includes.js");
 require("core-js/modules/esnext.iterator.constructor.js");
 require("core-js/modules/esnext.iterator.filter.js");
 require("core-js/modules/esnext.iterator.find.js");
@@ -320,7 +319,7 @@ const getRecord = async _ref4 => {
   const lookupsToFetch = [];
   const fields = model.formDef || model.columns;
   fields === null || fields === void 0 || fields.forEach(field => {
-    if (field.lookup && !lookupsToFetch.includes(field.lookup) && !_utils.default.emptyIdValues.includes(id) && !field.dependsOn) {
+    if (field.lookup && !lookupsToFetch.includes(field.lookup) && !field.dependsOn) {
       lookupsToFetch.push(field.lookup);
     }
   });

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -229,7 +229,7 @@ const getRecord = async ({ api, id, setIsLoading, setActiveRecord, model, parent
     const lookupsToFetch = [];
     const fields = model.formDef || model.columns;
     fields?.forEach(field => {
-        if (field.lookup && !lookupsToFetch.includes(field.lookup) && !utils.emptyIdValues.includes(id) && !field.dependsOn) {
+        if (field.lookup && !lookupsToFetch.includes(field.lookup) && !field.dependsOn) {
             lookupsToFetch.push(field.lookup);
         }
     });


### PR DESCRIPTION
Removed the unwanted condition for fetching the lookup.

We have this code snippet to fetch the lookups on the form

```
        if (field.lookup && !lookupsToFetch.includes(field.lookup) && !utils.emptyIdValues.includes(id) && !field.dependsOn) {
            lookupsToFetch.push(field.lookup);
        }
```

The condition ```!utils.emptyIdValues.includes(id)``` is not required, as it prevents lookups from loading on a new form request when the id falls under emptyIdValues.