### PR TITLE
Refine date formatting logic for better timezone handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework-ui",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "private": true,
   "type": "module",
   "main": "./index.js",

--- a/src/lib/components/Form/fields/dateTime.js
+++ b/src/lib/components/Form/fields/dateTime.js
@@ -8,6 +8,18 @@ dayjs.extend(utc);
 
 const Field = ({ column, field, formik, otherProps }) => {
     const { systemDateTimeFormat, stateData } = useStateContext();
+    const dateTimeValue = useMemo(() => {
+        const val = formik.values[field];
+        if (!val) return null;
+        if (column.localize) {
+            return dayjs(val);
+        }
+        // Non-localized: adjust UTC value to appear as local time so user sees raw UTC digits
+        let date = new Date(val);
+        const userTimezoneOffset = date.getTimezoneOffset() * 60000;
+        date = new Date(date.getTime() + userTimezoneOffset);
+        return dayjs(date);
+    }, [formik.values[field], column]);
     
     return <DateTimePicker
         {...otherProps}
@@ -17,7 +29,18 @@ const Field = ({ column, field, formik, otherProps }) => {
         fullWidth
         format={systemDateTimeFormat(false, false, stateData.dateTime)}
         name={field}
-        value={formik.values[field]}
+        value={dateTimeValue}
+        onChange={(value) => {
+            if (!value) {
+                formik.setFieldValue(field, null);
+            } else {
+                if (column.localize) {
+                    formik.setFieldValue(field, value.toISOString());
+                } else {
+                    formik.setFieldValue(field, value.utcOffset(0, true).toISOString());
+                }
+            }
+        }}
         onBlur={formik.handleBlur}
         helperText={formik.touched[field] && formik.errors[field]}
         minDateTime={(column.min ? dayjs(column.min) : null)}

--- a/src/lib/components/Form/fields/dateTime.js
+++ b/src/lib/components/Form/fields/dateTime.js
@@ -11,14 +11,7 @@ const Field = ({ column, field, formik, otherProps }) => {
     const dateTimeValue = useMemo(() => {
         const val = formik.values[field];
         if (!val) return null;
-        if (column.localize) {
-            return dayjs(val);
-        }
-        // Non-localized: adjust UTC value to appear as local time so user sees raw UTC digits
-        let date = new Date(val);
-        const userTimezoneOffset = date.getTimezoneOffset() * 60000;
-        date = new Date(date.getTime() + userTimezoneOffset);
-        return dayjs(date);
+        return dayjs(val);
     }, [formik.values[field], column]);
     
     return <DateTimePicker

--- a/src/lib/components/Form/fields/dateTime.js
+++ b/src/lib/components/Form/fields/dateTime.js
@@ -8,18 +8,6 @@ dayjs.extend(utc);
 
 const Field = ({ column, field, formik, otherProps }) => {
     const { systemDateTimeFormat, stateData } = useStateContext();
-    const dateTimeValue = useMemo(() => {
-        const val = formik.values[field];
-        if (!val) return null;
-        if (column.localize) {
-            return dayjs(val);
-        }
-        // Non-localized: adjust UTC value to appear as local time so user sees raw UTC digits
-        let date = new Date(val);
-        const userTimezoneOffset = date.getTimezoneOffset() * 60000;
-        date = new Date(date.getTime() + userTimezoneOffset);
-        return dayjs(date);
-    }, [formik.values[field], column]);
     
     return <DateTimePicker
         {...otherProps}
@@ -29,18 +17,7 @@ const Field = ({ column, field, formik, otherProps }) => {
         fullWidth
         format={systemDateTimeFormat(false, false, stateData.dateTime)}
         name={field}
-        value={dateTimeValue}
-        onChange={(value) => {
-            if (!value) {
-                formik.setFieldValue(field, null);
-            } else {
-                if (column.localize) {
-                    formik.setFieldValue(field, value.toISOString());
-                } else {
-                    formik.setFieldValue(field, value.utcOffset(0, true).toISOString());
-                }
-            }
-        }}
+        value={formik.values[field]}
         onBlur={formik.handleBlur}
         helperText={formik.touched[field] && formik.errors[field]}
         minDateTime={(column.min ? dayjs(column.min) : null)}

--- a/src/lib/components/Form/fields/time.js
+++ b/src/lib/components/Form/fields/time.js
@@ -6,6 +6,10 @@ import utcPlugin from 'dayjs/plugin/utc.js';
 dayjs.extend(utcPlugin);
 
 const field = ({ column, field, formik, otherProps }) => {
+    let inputValue = formik.values[field];
+    if (!column.localize && inputValue) {
+        inputValue = dayjs.utc(inputValue).utcOffset(dayjs().utcOffset(), true).format();
+    }
     return <TimePicker
         {...otherProps}
         variant="standard"
@@ -13,7 +17,13 @@ const field = ({ column, field, formik, otherProps }) => {
         key={field}
         fullWidth
         name={field}
-        value={formik.values[field]}
+        value={inputValue ? dayjs(inputValue) : null}
+        onChange={(value) => {
+            if (!column.localize) {
+                value = (value && value.isValid()) ? value.format('YYYY-MM-DDTHH:mm:ss') + '.000Z' : null;
+            }
+            return formik.setFieldValue(field, value);
+        }}
         onBlur={formik.handleBlur}
         helperText={formik.touched[field] && formik.errors[field]}
         slotProps={{ textField: { fullWidth: true, helperText: formik.errors[field], variant: "standard" } }}

--- a/src/lib/components/Form/fields/time.js
+++ b/src/lib/components/Form/fields/time.js
@@ -6,10 +6,6 @@ import utcPlugin from 'dayjs/plugin/utc.js';
 dayjs.extend(utcPlugin);
 
 const field = ({ column, field, formik, otherProps }) => {
-    let inputValue = formik.values[field];
-    if (!column.localize && inputValue) {
-        inputValue = dayjs.utc(inputValue).utcOffset(dayjs().utcOffset(), true).format();
-    }
     return <TimePicker
         {...otherProps}
         variant="standard"
@@ -17,13 +13,7 @@ const field = ({ column, field, formik, otherProps }) => {
         key={field}
         fullWidth
         name={field}
-        value={inputValue ? dayjs(inputValue) : null}
-        onChange={(value) => {
-            if (!column.localize) {
-                value = (value && value.isValid()) ? value.format('YYYY-MM-DDTHH:mm:ss') + '.000Z' : null;
-            }
-            return formik.setFieldValue(field, value);
-        }}
+        value={formik.values[field]}
         onBlur={formik.handleBlur}
         helperText={formik.touched[field] && formik.errors[field]}
         slotProps={{ textField: { fullWidth: true, helperText: formik.errors[field], variant: "standard" } }}

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -74,7 +74,9 @@ const dateParser = (value, utc = false) => {
         return new Date(value.slice(0, -1));
     }
 
-    throw new Error("Invalid date " + value);
+    // Fallback for other valid date formats (e.g. ISO without milliseconds, with offset)
+    const parsedValue = new Date(value);
+    return Number.isNaN(parsedValue.getTime()) ? value : parsedValue;
 };
 
 const buildRequestData = ({ gridColumns, page, pageSize, sortModel, filterModel, baseFilters, action = 'list', extraParams = {}, model, api }) => {

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -309,7 +309,7 @@ const getRecord = async (props = {}) => {
         throw new Error(getErrorMessage(response) || 'Load failed');
     }
     if (typeof model.parseResponsePayload === 'function' && model.parseResponseActions.includes('load')) {
-        return await model.parseResponsePayload({ responseData: response, model, action: 'load', ...props });
+        await model.parseResponsePayload({ responseData: response, model, action: 'load', ...props });
     }
     const { data: record, lookups } = response || {};
     let title = record[model.linkColumn];

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -15,6 +15,68 @@ function shouldApplyFilter(filter) {
     return isUnaryOperator || hasValidValue;
 }
 
+/**
+ * Parses a date string into a JavaScript Date object based on specific format lengths.
+ * * @param {string} value - The date string to parse.
+ * Supported formats:
+ * - 17 chars: "YYYYMMDDHHmmssSSS" (e.g., "20260413104406000")
+ * - 24 chars: "YYYY-MM-DDTHH:mm:ss.SSSZ" (e.g., "2026-04-13T10:44:06.000Z")
+ * @param {boolean} [utc=false] - If true, treats the input as UTC and returns a localized Date.
+ * If false, treats input as local time (for 17-char) or 
+ * strips the 'Z' (for 24-char) to treat as local.
+ * @returns {Date|string|null} - Returns a Date object, the original value if not a string, or null if empty.
+ * @throws {Error} - Throws error if the string length is not 17 or 24.
+ * * @example
+ * // Length 17: Treat as UTC and convert to local
+ * // Input: "20260413104406000"
+ * dateParser("20260413104406000", true); 
+ * * @example
+ * // Length 24: ISO format
+ * // Input: "2026-04-13T10:44:06.000Z"
+ * dateParser("2026-04-13T10:44:06.000Z", true);
+ */
+const dateParser = (value, utc = false) => {
+    // Validation: Return original value if it's not a string or is undefined/null
+    if (typeof value !== 'string' || value === undefined || value === null) {
+        return value;
+    }
+
+    // Handle empty strings
+    if (value.length === 0) {
+        return null;
+    }
+
+    // Handle "Compact" Format (YYYYMMDDHHmmssSSS)
+    if (value.length === 17) {
+        const year = +value.slice(0, 4);
+        const month = +value.slice(4, 6) - 1; // Months are 0-indexed in JS Date
+        const day = +value.slice(6, 8);
+        const hour = +value.slice(8, 10);
+        const min = +value.slice(10, 12);
+        const sec = +value.slice(12, 14);
+        const ms = +value.slice(14, 17);
+
+        if (utc) {
+            // Create Date as UTC, which the browser automatically localizes
+            return new Date(Date.UTC(year, month, day, hour, min, sec, ms));
+        }
+        // Create Date using system local time
+        return new Date(year, month, day, hour, min, sec, ms);
+    }
+
+    // Handle "ISO" Format (YYYY-MM-DDTHH:mm:ss.SSSZ)
+    if (value.length === 24) {
+        if (utc) {
+            // Standard behavior: 'Z' suffix indicates UTC
+            return new Date(value);
+        }
+        // Slice off the 'Z' to force the constructor to treat it as local time
+        return new Date(value.slice(0, -1));
+    }
+
+    throw new Error("Invalid date " + value);
+};
+
 const buildRequestData = ({ gridColumns, page, pageSize, sortModel, filterModel, baseFilters, action = 'list', extraParams = {}, model, api }) => {
     const isElasticExport = action === 'export' && model.isElasticExport === true;
 
@@ -191,18 +253,14 @@ const getList = async (props = {}) => {
 
     // Parse response data if needed custom processing.
     if (typeof model.parseResponsePayload === 'function' && model.parseResponseActions.includes(action)) {
-        return await model.parseResponsePayload({ responseData: response, model, dateColumns, action, ...props });
+        await model.parseResponsePayload({ responseData: response, model, dateColumns, action, ...props });
     }
 
     response.records.forEach(record => {
         dateColumns.forEach(column => {
             const { field, localize } = column;
             if (record[field]) {
-                record[field] = new Date(record[field]);
-                if (!localize) {
-                    const userTimezoneOffset = record[field].getTimezoneOffset() * 60000;
-                    record[field] = new Date(record[field].getTime() + userTimezoneOffset);
-                }
+                record[field] = dateParser(record[field], localize);
             }
         });
         model.columns.forEach(({ field, displayIndex }) => {

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -305,13 +305,13 @@ const GridBase = memo(({
         },
         "date": {
             "valueFormatter": (value, row, column) => (
-                formatDate({ value, useSystemFormat: true, showOnlyDate: false, state: stateData.dateTime, timeZone: column.localize ? timeZone : null, localize: column.localize })
+                formatDate({ value, useSystemFormat: true, showOnlyDate: false, state: stateData.dateTime })
             ),
             "filterOperators": LocalizedDatePicker({ columnType: "date", label: tTranslate('Value', tOpts) })
         },
         "dateTime": {
             "valueFormatter": (value, row, column) => (
-                formatDate({ value, useSystemFormat: false, showOnlyDate: false, state: stateData.dateTime, timeZone: column.localize ? timeZone : null, localize: column.localize })
+                formatDate({ value, useSystemFormat: false, showOnlyDate: false, state: stateData.dateTime })
             ),
             "filterOperators": LocalizedDatePicker({ columnType: "dateTime", label: tTranslate('Value', tOpts) })
         },

--- a/src/lib/components/useRouter/StateProvider.js
+++ b/src/lib/components/useRouter/StateProvider.js
@@ -97,7 +97,9 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   *
   * @param {Object} params - The parameters object.
   * @param {string|Date} params.value - The date value to format.
-  *   - Strings are always parsed as UTC (server-sent ISO strings are assumed to be UTC).
+  *   - Strings are always parsed as local time (display as-is). This ensures date-only values
+  *     like "2000-01-01" are never shifted by UTC offset. When `localize=true`, timezone
+  *     conversion is applied on top of the parsed local value.
   *   - Date objects behave differently based on `localize`:
   *     * localize=true  → raw UTC Date (as produced by crud-helper); parsed with dayjs.utc().
   *     * localize=false → offset-adjusted Date (pre-shifted by crud-helper); parsed with dayjs().
@@ -111,14 +113,13 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   const formatDate = useCallback(({ value, useSystemFormat, showOnlyDate = false, state, timeZone, localize = false }) => {
     if (!value) return null;
     const format = systemDateTimeFormat(useSystemFormat, showOnlyDate, state);
-    const isStringValue = typeof value === 'string';
+    // Strings are always parsed as local time to display the value as-is (no UTC offset shift).
+    // Date objects from crud-helper are raw UTC when localize=true, or pre-adjusted when localize=false.
+    const dayjsValue = (typeof value !== 'string' && localize) ? dayjs.utc(value) : dayjs(value);
     if (localize) {
-      if (!timeZone) {
-        return isStringValue ? dayjs(value).local().format(format) : dayjs.utc(value).local().format(format);
-      }
-      return isStringValue ? dayjs(value).tz(timeZone).format(format) : dayjs.utc(value).tz(timeZone).format(format);
+      return timeZone ? dayjsValue.tz(timeZone).format(format) : dayjsValue.local().format(format);
     }
-    return isStringValue ? dayjs.utc(value).format(format) : dayjs(value).format(format);
+    return dayjsValue.format(format);
   }, [systemDateTimeFormat]);
 
   /**

--- a/src/lib/components/useRouter/StateProvider.js
+++ b/src/lib/components/useRouter/StateProvider.js
@@ -97,9 +97,13 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   *
   * @param {Object} params - The parameters object.
   * @param {string|Date} params.value - The date value to format.
-  *   - Strings are always parsed as local time (display as-is). This ensures date-only values
-  *     like "2000-01-01" are never shifted by UTC offset. When `localize=true`, timezone
-  *     conversion is applied on top of the parsed local value.
+  *   - Strings without explicit timezone info (e.g. "2000-01-01", "2000-01-01T00:00:00") are
+  *     parsed as local time and displayed as-is. This ensures plain date values like birthdays
+  *     are never shifted by UTC offset.
+  *   - Strings with an explicit UTC marker or offset (e.g. "2000-01-01T00:00:00Z",
+  *     "2000-01-01T00:00:00+05:30") are parsed as UTC/offset-aware:
+  *     * localize=false → displayed in UTC (no conversion).
+  *     * localize=true  → converted to the target timezone/local time.
   *   - Date objects behave differently based on `localize`:
   *     * localize=true  → raw UTC Date (as produced by crud-helper); parsed with dayjs.utc().
   *     * localize=false → offset-adjusted Date (pre-shifted by crud-helper); parsed with dayjs().
@@ -113,9 +117,15 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   const formatDate = useCallback(({ value, useSystemFormat, showOnlyDate = false, state, timeZone, localize = false }) => {
     if (!value) return null;
     const format = systemDateTimeFormat(useSystemFormat, showOnlyDate, state);
-    // Strings are always parsed as local time to display the value as-is (no UTC offset shift).
-    // Date objects from crud-helper are raw UTC when localize=true, or pre-adjusted when localize=false.
-    const dayjsValue = (typeof value !== 'string' && localize) ? dayjs.utc(value) : dayjs(value);
+    const isStringValue = typeof value === 'string';
+    // Detect strings that carry explicit UTC/offset info (e.g. "...Z" or "...+05:30").
+    // Plain strings (date-only or no-tz datetime) are treated as local to display as-is.
+    const hasExplicitTz = isStringValue && /Z$|[+-]\d{2}:?\d{2}$/.test(value);
+    // Use dayjs.utc when: Date object + localize=true (raw UTC from crud-helper),
+    //                  or UTC/offset string + localize=false (preserve the UTC display value).
+    const dayjsValue = (!isStringValue && localize) || (!localize && hasExplicitTz)
+      ? dayjs.utc(value)
+      : dayjs(value);
     if (localize) {
       return timeZone ? dayjsValue.tz(timeZone).format(format) : dayjsValue.local().format(format);
     }

--- a/src/lib/components/useRouter/StateProvider.js
+++ b/src/lib/components/useRouter/StateProvider.js
@@ -97,6 +97,10 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   *
   * @param {Object} params - The parameters object.
   * @param {string|Date} params.value - The date value to format.
+  *   - Strings are always parsed as UTC (server-sent ISO strings are assumed to be UTC).
+  *   - Date objects behave differently based on `localize`:
+  *     * localize=true  → raw UTC Date (as produced by crud-helper); parsed with dayjs.utc().
+  *     * localize=false → offset-adjusted Date (pre-shifted by crud-helper); parsed with dayjs().
   * @param {boolean} params.useSystemFormat - Whether to use the system date format.
   * @param {boolean} [params.showOnlyDate=false] - Whether to show only the date part.
   * @param {string|null|undefined} params.state - The user-defined date/time format string.
@@ -106,15 +110,15 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   */
   const formatDate = useCallback(({ value, useSystemFormat, showOnlyDate = false, state, timeZone, localize = false }) => {
     if (!value) return null;
-    const format = systemDateTimeFormat(useSystemFormat, showOnlyDate, state); // Pass 'state' as an argument
-    const isStringValue = typeof value === 'string';
+    const format = systemDateTimeFormat(useSystemFormat, showOnlyDate, state);
+    // Normalize value upfront to a single dayjs object:
+    // - Strings and localize=true Date objects are raw UTC → parse with dayjs.utc().
+    // - localize=false Date objects are already offset-adjusted by crud-helper → parse with dayjs().
+    const dayjsValue = (typeof value === 'string' || localize) ? dayjs.utc(value) : dayjs(value);
     if (localize) {
-      if (!timeZone) {
-        return isStringValue ? dayjs(value).local().format(format) : dayjs.utc(value).local().format(format);
-      }
-      return isStringValue ? dayjs(value).tz(timeZone).format(format) : dayjs.utc(value).tz(timeZone).format(format);
+      return timeZone ? dayjsValue.tz(timeZone).format(format) : dayjsValue.local().format(format);
     }
-    return isStringValue ? dayjs.utc(value).format(format) : dayjs(value).format(format);
+    return dayjsValue.format(format);
   }, [systemDateTimeFormat]);
 
   /**

--- a/src/lib/components/useRouter/StateProvider.js
+++ b/src/lib/components/useRouter/StateProvider.js
@@ -111,14 +111,14 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   const formatDate = useCallback(({ value, useSystemFormat, showOnlyDate = false, state, timeZone, localize = false }) => {
     if (!value) return null;
     const format = systemDateTimeFormat(useSystemFormat, showOnlyDate, state);
-    // Normalize value upfront to a single dayjs object:
-    // - Strings and localize=true Date objects are raw UTC → parse with dayjs.utc().
-    // - localize=false Date objects are already offset-adjusted by crud-helper → parse with dayjs().
-    const dayjsValue = (typeof value === 'string' || localize) ? dayjs.utc(value) : dayjs(value);
+    const isStringValue = typeof value === 'string';
     if (localize) {
-      return timeZone ? dayjsValue.tz(timeZone).format(format) : dayjsValue.local().format(format);
+      if (!timeZone) {
+        return isStringValue ? dayjs(value).local().format(format) : dayjs.utc(value).local().format(format);
+      }
+      return isStringValue ? dayjs(value).tz(timeZone).format(format) : dayjs.utc(value).tz(timeZone).format(format);
     }
-    return dayjsValue.format(format);
+    return isStringValue ? dayjs.utc(value).format(format) : dayjs(value).format(format);
   }, [systemDateTimeFormat]);
 
   /**

--- a/src/lib/components/useRouter/StateProvider.js
+++ b/src/lib/components/useRouter/StateProvider.js
@@ -92,29 +92,30 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
     return isDateFormatOnly?.split(' ')[0] || 'DD-MM-YYYY';
   }, []);
 
-  /**
-  * Formats a date value using system or user-defined format with optional timezone and UTC handling.
-  *
-  * @param {Object} params - The parameters object.
-  * @param {string|Date} params.value - The date value to format.
-  *   - Strings without explicit timezone info (e.g. "2000-01-01", "2000-01-01T00:00:00") are
-  *     parsed as local time and displayed as-is. This ensures plain date values like birthdays
-  *     are never shifted by UTC offset.
-  *   - Strings with an explicit UTC marker or offset (e.g. "2000-01-01T00:00:00Z",
-  *     "2000-01-01T00:00:00+05:30") are parsed as UTC/offset-aware:
-  *     * localize=false → displayed in UTC (no conversion).
-  *     * localize=true  → converted to the target timezone/local time.
-  *   - Date objects behave differently based on `localize`:
-  *     * localize=true  → raw UTC Date (as produced by crud-helper); parsed with dayjs.utc().
-  *     * localize=false → offset-adjusted Date (pre-shifted by crud-helper); parsed with dayjs().
-  * @param {boolean} params.useSystemFormat - Whether to use the system date format.
-  * @param {boolean} [params.showOnlyDate=false] - Whether to show only the date part.
-  * @param {string|null|undefined} params.state - The user-defined date/time format string.
-  * @returns {string|null} The formatted date string, or `null` if value is falsy.
-  */
+/**
+   * Formats a date or date-string into a localized or system-defined string format.
+   * * @param {Object} params - The formatting configuration.
+   * @param {string|Date|dayjs.Dayjs} params.value - The date value to format. 
+   * - Strings without offsets are treated as local time.
+   * - Strings with offsets/Z are parsed as specific points in time.
+   * @param {boolean} params.useSystemFormat - If true, ignores `state` and uses the 
+   * globally configured system date/time format.
+   * @param {boolean} [params.showOnlyDate=false] - If true, excludes the time portion 
+   * from the resulting string.
+   * @param {string|null|undefined} params.state - A custom format string (e.g., "DD/MM/YYYY") 
+   * used if `useSystemFormat` is false.
+   * * @returns {string|null} The formatted date string, or `null` if the input value is falsy.
+   * * @example
+   * formatDate({ value: '2023-10-01', useSystemFormat: true });
+   * // Returns "Oct 1, 2023" (depending on system settings)
+   */
   const formatDate = useCallback(({ value, useSystemFormat, showOnlyDate = false, state }) => {
     if (!value) return null;
-    const format = systemDateTimeFormat(useSystemFormat, showOnlyDate, state); // Pass 'state' as an argument
+
+    // Get the appropriate format string based on system settings or user preference
+    const format = systemDateTimeFormat(useSystemFormat, showOnlyDate, state);
+
+    // Parse and format using dayjs
     return dayjs(value).format(format);
   }, [systemDateTimeFormat]);
 

--- a/src/lib/components/useRouter/StateProvider.js
+++ b/src/lib/components/useRouter/StateProvider.js
@@ -26,13 +26,13 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   const [pageBackButton, setPageBackButtonState] = useState(null);
   const [userData, setUserDataState] = useState(null);
   const [timeZone, setTimeZoneState] = useState('');
-  
+
   // Framework functionality - loader management (simple on/off, no counter)
   const [isLoading, setIsLoading] = useState(false);
-  
+
   // Framework functionality - i18n
   const { t, i18n } = useTranslation();
-  
+
   // Framework functionality - snackbar
   const snackbar = useSnackbar();
 
@@ -107,13 +107,14 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   const formatDate = useCallback(({ value, useSystemFormat, showOnlyDate = false, state, timeZone, localize = false }) => {
     if (!value) return null;
     const format = systemDateTimeFormat(useSystemFormat, showOnlyDate, state); // Pass 'state' as an argument
-    if(localize) {
+    const isStringValue = typeof value === 'string';
+    if (localize) {
       if (!timeZone) {
-        return dayjs.utc(value).local().format(format);
+        return isStringValue ? dayjs(value).local().format(format) : dayjs.utc(value).local().format(format);
       }
-      return dayjs.utc(value).tz(timeZone).format(format);
+      return isStringValue ? dayjs(value).tz(timeZone).format(format) : dayjs.utc(value).tz(timeZone).format(format);
     }
-    return dayjs(value).format(format);
+    return isStringValue ? dayjs.utc(value).format(format) : dayjs(value).format(format);
   }, [systemDateTimeFormat]);
 
   /**
@@ -193,30 +194,30 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   const contextValue = useMemo(() => ({
     // State data
     stateData,
-    
+
     // Loader management
     isLoading,
     showLoader,
-    
+
     // Snackbar utilities
     showMessage: snackbar?.showMessage || snackbarWarning,
     showError: snackbar?.showError || snackbarWarning,
-    
+
     // i18n utilities
     dayjs,
     t,
     i18n,
-    
+
     // Date/time utilities
     systemDateTimeFormat,
     formatDate,
     useLocalization,
-    
+
     // API utilities
     getApiEndpoint,
     setApiEndpoint,
     buildUrl,
-    
+
     // App-level state setters with meaningful names
     setLocale,
     setPageTitle,
@@ -226,8 +227,8 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
     setDateTimeFormat,
     setModal
   }), [stateData, isLoading, showLoader, t, i18n, snackbar,
-       getApiEndpoint, setApiEndpoint, systemDateTimeFormat, formatDate, useLocalization,
-       setLocale, setPageTitle, setPageBackButton, setUserData, setTimeZone, setDateTimeFormat, setModal, buildUrl]);
+    getApiEndpoint, setApiEndpoint, systemDateTimeFormat, formatDate, useLocalization,
+    setLocale, setPageTitle, setPageBackButton, setUserData, setTimeZone, setDateTimeFormat, setModal, buildUrl]);
 
   return (
     <StateContext.Provider value={contextValue}>

--- a/src/lib/components/useRouter/StateProvider.js
+++ b/src/lib/components/useRouter/StateProvider.js
@@ -110,26 +110,12 @@ const StateProvider = ({ children, apiEndpoints: initialApiEndpoints = {} }) => 
   * @param {boolean} params.useSystemFormat - Whether to use the system date format.
   * @param {boolean} [params.showOnlyDate=false] - Whether to show only the date part.
   * @param {string|null|undefined} params.state - The user-defined date/time format string.
-  * @param {string} [params.timeZone] - The timezone to use for formatting.
-  * @param {boolean} [params.localize=false] - Whether to localize the date.
   * @returns {string|null} The formatted date string, or `null` if value is falsy.
   */
-  const formatDate = useCallback(({ value, useSystemFormat, showOnlyDate = false, state, timeZone, localize = false }) => {
+  const formatDate = useCallback(({ value, useSystemFormat, showOnlyDate = false, state }) => {
     if (!value) return null;
-    const format = systemDateTimeFormat(useSystemFormat, showOnlyDate, state);
-    const isStringValue = typeof value === 'string';
-    // Detect strings that carry explicit UTC/offset info (e.g. "...Z" or "...+05:30").
-    // Plain strings (date-only or no-tz datetime) are treated as local to display as-is.
-    const hasExplicitTz = isStringValue && /Z$|[+-]\d{2}:?\d{2}$/.test(value);
-    // Use dayjs.utc when: Date object + localize=true (raw UTC from crud-helper),
-    //                  or UTC/offset string + localize=false (preserve the UTC display value).
-    const dayjsValue = (!isStringValue && localize) || (!localize && hasExplicitTz)
-      ? dayjs.utc(value)
-      : dayjs(value);
-    if (localize) {
-      return timeZone ? dayjsValue.tz(timeZone).format(format) : dayjsValue.local().format(format);
-    }
-    return dayjsValue.format(format);
+    const format = systemDateTimeFormat(useSystemFormat, showOnlyDate, state); // Pass 'state' as an argument
+    return dayjs(value).format(format);
   }, [systemDateTimeFormat]);
 
   /**


### PR DESCRIPTION
Updates the date formatting utility to differentiate between string and non-string inputs, ensuring more accurate UTC and local time conversions. This adjustment prevents parsing inconsistencies when applying localizations or specific timezones.

Increments the package version to 2.0.9.