### PR TITLE
Simplifies date picker styling and lookup handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework-ui",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "private": true,
   "type": "module",
   "main": "./index.js",

--- a/src/lib/components/Grid/LocalizedDatePicker.js
+++ b/src/lib/components/Grid/LocalizedDatePicker.js
@@ -69,7 +69,10 @@ const LocalizedDatePicker = (props) => {
                 onChange={handleFilterChange}
                 slotProps={{
                     textField: {
-                        variant: "standard"
+                        variant: "standard",
+                        inputProps: {
+                            'aria-label': 'date-input'
+                        }
                     }
                 }}
                 localeText={{

--- a/src/lib/components/Grid/LocalizedDatePicker.js
+++ b/src/lib/components/Grid/LocalizedDatePicker.js
@@ -14,8 +14,6 @@ const componentMap = {
     date: DatePicker,
     dateTime: DateTimePicker
 };
-const DATEPICKER_MARGIN_TOP = '-10px';
-const DATEPICKER_MARGIN_BOTTOM = '-16px';
 
 const LocalizedDatePicker = (props) => {
     const { fixedFilterFormat } = utils;
@@ -71,20 +69,7 @@ const LocalizedDatePicker = (props) => {
                 onChange={handleFilterChange}
                 slotProps={{
                     textField: {
-                        variant: "standard", label: props.label,
-                        sx: {
-                            marginTop: DATEPICKER_MARGIN_TOP,
-                            marginBottom: DATEPICKER_MARGIN_BOTTOM,
-                            '& .MuiInputLabel-root': {
-                                marginTop: '5px',
-                            },
-                            '& .MuiInput-root': {
-                                marginTop: '5px',
-                            },
-                            '&.MuiFormControl-root.MuiPickersTextField-root': {
-                                marginTop: '-20px',
-                            }
-                        }
+                        variant: "standard"
                     }
                 }}
                 localeText={{

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -151,14 +151,14 @@ const buildRequestData = ({ gridColumns, page, pageSize, sortModel, filterModel,
     const lookups = [];
     const lookupWithDeps = []; // for backward compatibility having two lookups arrays
     const dateColumns = [];
-    gridColumns.forEach(({ lookup, type, field, localize = false, filterable = true, dependsOn }) => {
+    gridColumns.forEach(({ lookup, type, field, localize = false, dependsOn }) => {
         if (dateDataTypes.includes(type)) {
             dateColumns.push({ field, localize });
         }
         if (!lookup) {
             return;
         }
-        if (!lookups.includes(lookup) && lookupDataTypes.includes(type) && filterable) {
+        if (!lookups.includes(lookup) && lookupDataTypes.includes(type)) {
             lookups.push(lookup);
             lookupWithDeps.push({ lookup, dependsOn });
         }

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -359,13 +359,13 @@ const GridBase = memo(({
             "valueFormatter": (value, row, column) => (
                 formatDate({ value, useSystemFormat: true, showOnlyDate: false, state: stateData.dateTime })
             ),
-            "filterOperators": LocalizedDatePicker({ columnType: "date", label: tTranslate('Value', tOpts) })
+            "filterOperators": LocalizedDatePicker({ columnType: "date" })
         },
         "dateTime": {
             "valueFormatter": (value, row, column) => (
                 formatDate({ value, useSystemFormat: false, showOnlyDate: false, state: stateData.dateTime })
             ),
-            "filterOperators": LocalizedDatePicker({ columnType: "dateTime", label: tTranslate('Value', tOpts) })
+            "filterOperators": LocalizedDatePicker({ columnType: "dateTime" })
         },
         "boolean": {
             renderCell: booleanIconRenderer
@@ -573,6 +573,10 @@ const GridBase = memo(({
             auditColumnMappings.forEach(({ key, field, type, header }) => {
                 if (auditColumns[key] === true) {
                     const column = { field, type, headerName: tTranslate(header, tOpts), width: 200 };
+                    // Apply shared grid column type overrides (renderers, valueOptions, etc.)
+                    if (updatedColumnType && updatedColumnType[column.type]) {
+                        Object.assign(column, updatedColumnType[column.type]);
+                    }
                     if (type === constants.dateTime) {
                         column.filterOperators = LocalizedDatePicker({ columnType: 'dateTime' });
                         column.valueFormatter = gridColumnTypes.dateTime.valueFormatter;


### PR DESCRIPTION
Removes custom margin styling and label props from the date picker to streamline appearance and usage.

Eliminates filterability check for lookup columns to ensure all lookups are included, improving consistency for data requests.

Centralizes grid column type overrides to reduce redundancy and enhance maintainability.