### PR TITLE
feat(grid): added custom dropdown filter component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework-ui",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "private": true,
   "type": "module",
   "main": "./index.js",

--- a/src/lib/components/Grid/CustomDropDownMenu.js
+++ b/src/lib/components/Grid/CustomDropDownMenu.js
@@ -1,0 +1,112 @@
+import React, { useMemo, useCallback } from 'react';
+import {
+    useGridSelector,
+    gridFilterModelSelector
+} from '@mui/x-data-grid-premium';
+
+import { Box, FormControl, IconButton, MenuItem, Select } from '@mui/material';
+import ClearIcon from '@mui/icons-material/Clear';
+
+const GridOperators = {
+    IsAnyOf: 'isAnyOf'
+};
+
+const CustomDropdownMenu = (props) => {
+    const { column, item, applyValue, apiRef } = props;
+    const lookupData = column?.dataRef?.current?.lookups;
+    let options = column?.customLookup || lookupData[column.lookup] || [];
+
+    if (typeof column.lookup === 'string') {
+        options = options.map(({ label, value }) => ({
+            label,
+            value
+        }));
+    }
+
+    const filterModel = useGridSelector(apiRef, gridFilterModelSelector);
+    const currentFieldFilters = useMemo(
+        () =>
+            filterModel.items?.filter((value) => {
+                return value.field === column.field;
+            }),
+        [column.field, filterModel.items]
+    );
+
+    const handleFilterChange = useCallback(
+        (event) => {
+            let inputValue = event.target.value;
+            if (filterModel.items.length >= 1) {
+                inputValue = inputValue.length === 1 ? inputValue[0] : inputValue;
+
+                for (const element of filterModel.items) {
+                    if (element.field !== item.field) {
+                        continue;
+                    }
+                    if (element.operator === GridOperators.IsAnyOf) {
+                        inputValue = Array.isArray(inputValue) ? inputValue : [inputValue];
+                    } else {
+                        inputValue = inputValue === 0 ? '0' : inputValue;
+                    }
+                }
+            }
+
+            if (inputValue.length === 0 && currentFieldFilters[0]) {
+                apiRef.current.deleteFilterItem(currentFieldFilters[0]);
+                return;
+            }
+
+            const newValue = inputValue;
+            const newitem = currentFieldFilters[0] ? currentFieldFilters[0] : item;
+            applyValue({ ...newitem, value: newValue });
+        },
+        [apiRef, column.applyZeroFilter, currentFieldFilters, item, applyValue]
+    );
+
+    const handleClear = useCallback(
+        (e) => {
+            e.stopPropagation();
+            if (currentFieldFilters[0]) {
+                apiRef.current.deleteFilterItem(currentFieldFilters[0]);
+            }
+        },
+        [apiRef, currentFieldFilters]
+    );
+
+    const value = currentFieldFilters[0]?.value ?? '';
+    const hasValue = Array.isArray(value) ? value.length > 0 : value !== '';
+
+    return (
+        <Box sx={{ display: 'flex', alignItems: 'flex-end', width: '100%' }}>
+            <FormControl variant="standard" sx={{ flex: 1 }}>
+                <Select
+                    label={column.field}
+                    variant="standard"
+                    value={value}
+                    onChange={(e) => handleFilterChange(e)}
+                    multiple={Array.isArray(value)}
+                    MenuProps={{
+                        PaperProps: {
+                            style: {
+                                maxHeight: 400,
+                                overflowY: 'auto'
+                            }
+                        }
+                    }}
+                >
+                    {options?.map((option, index) => (
+                        <MenuItem key={index} value={option.value}>
+                            {props.tTranslate(option.label, props.tOpts)}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+            {hasValue && (
+                <IconButton size="small" onClick={handleClear} sx={{ mb: '2px' }}>
+                    <ClearIcon sx={{ fontSize: 16 }} />
+                </IconButton>
+            )}
+        </Box>
+    );
+};
+
+export default CustomDropdownMenu;

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -5,7 +5,10 @@ import {
     useGridApiRef,
     useGridApiContext,
     useGridSelector,
-    gridRowSelectionStateSelector
+    gridRowSelectionStateSelector,
+    getGridStringOperators,
+    getGridBooleanOperators,
+    getGridDateOperators
 } from '@mui/x-data-grid-premium';
 import DeleteIcon from '@mui/icons-material/Delete';
 import CopyIcon from '@mui/icons-material/FileCopy';
@@ -31,6 +34,7 @@ import Checkbox from '@mui/material/Checkbox';
 import { useModelTranslation } from '../../hooks/useModelTranslation';
 import { convertDefaultSort, areEqual, getDefaultOperator } from './helper';
 import { styled } from '@mui/material/styles';
+import CustomDropdownMenu from './CustomDropDownMenu';
 
 const defaultPageSize = 50;
 const sortRegex = /(\w+)( ASC| DESC)?/i;
@@ -537,9 +541,30 @@ const GridBase = memo(({
             if (updatedColumnType[column.type]) {
                 Object.assign(overrides, updatedColumnType[column.type]);
             }
-            // Common filter operator pattern
             if (overrides.valueOptions === constants.lookup) {
-                overrides.valueOptions = (params) => lookupOptions({ ...params, lookupMap });
+                let operators = [];
+
+                if (overrides.valueOptions === constants.lookup) {
+                    overrides.valueOptions = (params) => lookupOptions({ ...params, lookupMap });
+                    const lookupFilters = [...getGridDateOperators(), ...getGridStringOperators()]
+                        .filter((op) => ['is', 'not', 'isAnyOf'].includes(op.value));
+                    operators = lookupFilters;
+                }
+
+                overrides.filterOperators = operators.map((operator) => ({
+                    ...operator,
+                    InputComponent: operator.InputComponent
+                        ? (params) => (
+                            <CustomDropdownMenu
+                                column={{...column, dataRef }}
+                                {...params}
+                                autoHighlight
+                                tTranslate={tTranslate}
+                                tOpts={tOpts}
+                            />
+                        )
+                        : undefined
+                }));
             }
             if (column.linkTo || column.link) {
                 overrides.cellClassName = 'mui-grid-linkColumn';


### PR DESCRIPTION
Created CustomDropdownMenu component to provide enhanced filtering UI for lookup-based grid columns. Supports single and multiple value selection with clearing capability. Updated Grid to integrate custom dropdown component with filter operators for 'is', 'not', and 'isAnyOf' operators. Includes i18n translation support for option labels. Bumps version to 2.0.17.

Co-authored-by: Copilot <copilot@github.com>