### PR TITLE
#74382-improved filtering, pagination, and column memoization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework-ui",
-  "version": "2.0.17",
+  "version": "2.0.18",
   "private": true,
   "type": "module",
   "main": "./index.js",

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -175,7 +175,7 @@ const buildRequestData = ({ gridColumns, page, pageSize, sortModel, filterModel,
                 if (type === 'boolean') {
                     value = (value === 'true' || value === true) ? 1 : 0;
                 } else if (type === 'number') {
-                    value = Array.isArray(value) ? value.filter(e => e) : value;
+                    value = Array.isArray(value) ? value.filter(e => e !== null && e !== undefined && e !== '') : value;
                 }
                 value = filter.filterValues || value;
                 where.push({

--- a/src/lib/components/Grid/footer.js
+++ b/src/lib/components/Grid/footer.js
@@ -13,6 +13,7 @@ const Footer = ({ pagination, apiRef, tTranslate = (key) => key }) => {
     const rowsPerPage = apiRef.current.state.pagination.paginationModel.pageSize;
     const totalRows = apiRef.current.state.rows.totalRowCount;
     const totalPages = Math.ceil(totalRows / rowsPerPage);
+    const isPaginationEnabled = pagination && totalPages > 1;
     const { t: translate, i18n } = useTranslation();
     const tOpts = { t: translate, i18n };
     const [pageNumber, setPageNumber] = useState(page + 1);
@@ -72,9 +73,9 @@ const Footer = ({ pagination, apiRef, tTranslate = (key) => key }) => {
                             value={pageNumber}
                             onChange={handleChange}
                             onKeyPress={handleKeyPress}
-                            disabled={!totalRows}
+                            disabled={!isPaginationEnabled}
                         />
-                        <Button disabled={!totalRows} size='small' onClick={onPageChange}>{tTranslate('Go', tOpts)}</Button>
+                        <Button disabled={!isPaginationEnabled} size='small' onClick={onPageChange}>{tTranslate('Go', tOpts)}</Button>
                     </>
                 }
             </Box>

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -551,9 +551,9 @@ const GridBase = memo(({
 
             if (updatedColumnType[column.type]) {
                 Object.assign(overrides, updatedColumnType[column.type]);
-                if (column.filterOperators) {
-                    overrides.filterOperators = column.filterOperators;
-                }
+            }
+            if (column.filterOperators) {
+                overrides.filterOperators = column.filterOperators;
             }
             // Common filter operator pattern
             if (overrides.valueOptions === constants.lookup) {
@@ -577,7 +577,8 @@ const GridBase = memo(({
             if (!disableRowGrouping) {
                 overrides.groupable = column.groupable ?? false;
             }
-            overrides.filterable = column.filterable === false ? false : !groupingModel.includes(column.field);
+            const finalField = overrides.field ?? column.field;
+            overrides.filterable = column.filterable === false ? false : !groupingModel.includes(finalField);
             const headerName = tTranslate((typeof column.gridLabel === 'function' ? column.gridLabel({ column, t: tTranslate, tOpts }) : column.gridLabel) || column.label, tOpts);
 
             finalColumns.push({ ...column, ...overrides, headerName, description: headerName });

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -385,7 +385,7 @@ const GridBase = memo(({
             renderCell: (params) => <CustomCheckBox params={params} handleSelectRow={handleSelectRow} idProperty={idProperty} />
         },
         "percentage": {
-            type: "decimal",
+            type: "number",
             align: 'right',
             filterOperators: [...getGridNumericOperators()].filter(op => !['!='].includes(op.value)),
             "valueFormatter": (value) => {

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -532,7 +532,7 @@ const GridBase = memo(({
         return Object.keys(lookups).sort().join(',');
     }, [data?.lookups]);
 
-    const { gridColumns, pinnedColumns, lookupMap } = useMemo(() => {
+    const { stableGridColumns, pinnedColumns, lookupMap } = useMemo(() => {
         let baseColumnList = columns || model.gridColumns || model.columns;
         if (dynamicColumns) {
             baseColumnList = [...dynamicColumns, ...baseColumnList];
@@ -551,6 +551,9 @@ const GridBase = memo(({
 
             if (updatedColumnType[column.type]) {
                 Object.assign(overrides, updatedColumnType[column.type]);
+                if (column.filterOperators) {
+                    overrides.filterOperators = column.filterOperators;
+                }
             }
             // Common filter operator pattern
             if (overrides.valueOptions === constants.lookup) {
@@ -574,6 +577,7 @@ const GridBase = memo(({
             if (!disableRowGrouping) {
                 overrides.groupable = column.groupable ?? false;
             }
+            overrides.filterable = column.filterable === false ? false : !groupingModel.includes(column.field);
             const headerName = tTranslate((typeof column.gridLabel === 'function' ? column.gridLabel({ column, t: tTranslate, tOpts }) : column.gridLabel) || column.label, tOpts);
 
             finalColumns.push({ ...column, ...overrides, headerName, description: headerName });
@@ -615,8 +619,12 @@ const GridBase = memo(({
 
             pinnedColumns.right.push('actions');
         }
-        return { gridColumns: finalColumns, pinnedColumns, lookupMap };
-    }, [columns, model, parent, permissions, forAssignment, dynamicColumns, translate, stateData?.dateTime, lookupKeys]);
+        return { stableGridColumns: finalColumns, pinnedColumns, lookupMap };
+    }, [columns, model, parent, permissions, forAssignment, dynamicColumns, translate, stateData?.dateTime, groupingModel]);
+
+    // Shallow-copy columns when lookups change so MUI DataGrid's GridFilterInputSingleSelect
+    // sees new column object references and re-evaluates its memoized currentValueOptions.
+    const gridColumns = useMemo(() => stableGridColumns.map(col => ({ ...col })), [stableGridColumns, lookupKeys]);
 
     // Initialize toolbar filters with default values
     const hasInitializedRef = useRef(false);
@@ -739,7 +747,7 @@ const GridBase = memo(({
             pageSize: isExportRequest ? exportPageSize : pageSize,
             sortModel: sortModelForFetch,
             filterModel: filters,
-            gridColumns,
+            gridColumns: stableGridColumns,
             model,
             baseFilters: mergedBaseFilters,
             api: baseUrl,
@@ -765,7 +773,7 @@ const GridBase = memo(({
         } finally {
             if (!isExportRequest && fetchAbortControllerRef.current === controller) setIsLoading(false);
         }
-    }, [hasStaticData, normalizedStaticData, paginationModelForFetch, buildUrl, model, backendApi, filterModelForFetch, baseFilters, id, assigned, available, selected, props.extraParams, sortModelForFetch, gridColumns, parentFilters, onListParamsChange, apiRef, getList, snackbar, additionalFilters, tTranslate, tOpts]);
+    }, [hasStaticData, normalizedStaticData, paginationModelForFetch, buildUrl, model, backendApi, filterModelForFetch, baseFilters, id, assigned, available, selected, props.extraParams, sortModelForFetch, stableGridColumns, parentFilters, onListParamsChange, apiRef, getList, snackbar, additionalFilters, tTranslate, tOpts]);
 
     const openForm = useCallback(async ({ id, record = {}, mode }) => {
         if (setActiveRecord) {
@@ -1133,7 +1141,8 @@ const GridBase = memo(({
             }
             return { ...item, value: isNumber ? null : value };
         });
-        setFilterModel({ ...e, items: updatedItems });
+        const filteredItems = updatedItems.filter(item => !(item.operator === 'isAnyOf' && Array.isArray(item.value) && item.value.length === 0));
+        setFilterModel({ ...e, items: filteredItems });
     }, [gridColumns, constants.Number, emptyIsAnyOfOperatorFilters, isElasticScreen, setFilterModel]);
 
     const updateSort = useCallback((e) => {

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -1066,7 +1066,7 @@ const GridBase = memo(({
         const nonExportColumns = new Set(gridColumns.filter(col => col.exportable === false).map(col => col.field));
 
         const visibleColumns = orderedFields.filter(
-            field => !nonExportColumns.has(field) && !hiddenColumns.includes(field) && field !== '__check__' && field !== 'actions'
+            field => !nonExportColumns.has(field) && !hiddenColumns.includes(field) && field !== '__check__' && field !== 'actions' && !gridGroupByColumnName.includes(field)
         );
 
         if (visibleColumns.length === 0) {

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -5,7 +5,8 @@ import {
     useGridApiRef,
     useGridApiContext,
     useGridSelector,
-    gridRowSelectionStateSelector
+    gridRowSelectionStateSelector,
+    getGridNumericOperators
 } from '@mui/x-data-grid-premium';
 import DeleteIcon from '@mui/icons-material/Delete';
 import CopyIcon from '@mui/icons-material/FileCopy';
@@ -382,7 +383,27 @@ const GridBase = memo(({
         },
         "selection": {
             renderCell: (params) => <CustomCheckBox params={params} handleSelectRow={handleSelectRow} idProperty={idProperty} />
-        }
+        },
+        "percentage": {
+            type: "decimal",
+            align: 'right',
+            filterOperators: [...getGridNumericOperators()].filter(op => !['!='].includes(op.value)),
+            "valueFormatter": (value) => {
+                if (value == null) return '';
+                const numericValue = Number(value);
+                return !isNaN(numericValue) ? `${numericValue.toFixed(1)}%` : '';
+            }
+        },
+        "currency": {
+            type: "number",
+            align: 'right',
+            filterOperators: [...getGridNumericOperators()].filter(op => !['!='].includes(op.value)),
+            "valueFormatter": (value) => {
+                if (value == null) return '';
+                const symbol = userData?.userData?.CurrencySymbol || '';
+                return symbol ? `${symbol}${value}` : String(value);
+            }
+        },
     };
 
     useEffect(() => {


### PR DESCRIPTION
Fixed number field filtering to explicitly exclude null, undefined, and empty string values instead of relying on loose truthiness checks. Fixed pagination button states to only enable when pagination is available and there are multiple pages, not just when rows exist. Refactored column memoization to separate stable column definitions from lookup-dependent shallow copies, ensuring MUI DataGrid re-evaluates filter options when lookups change. Added support for custom filterOperators and filterable properties on columns. Updated filter model handling to remove empty isAnyOf filter items, preventing invalid filter states. Updated dependency arrays to use stableGridColumns and groupingModel for proper memoization tracking.