### PR TITLE
Add centralized error codes and unify error/message handling

### DIFF
--- a/src/lib/components/Form/Form.js
+++ b/src/lib/components/Form/Form.js
@@ -193,7 +193,7 @@ const Form = ({
         .catch((err) => {
           snackbar.showErrorCode(
             ERROR_CODES.AN_ERROR_OCCURRED,
-            err
+            err?.message
           );
           if (model.reloadOnSave) {
             resetForm();

--- a/src/lib/components/Form/Form.js
+++ b/src/lib/components/Form/Form.js
@@ -269,9 +269,7 @@ const Form = ({
         navigateBack !== false && handleNavigation();
       }
     } catch (error) {
-      snackbar.showErrorCode(ERROR_CODES.AN_ERROR_OCCURRED, error?.message);
-    } finally {
-      setIsDeleting(false);
+      snackbar.showErrorCode(ERROR_CODES.DELETE_FAILED, error?.message);
     }
   }, [id, api, model.api, snackbar, setErrorMessage, model, navigateBack, handleNavigation, tTranslate, tOpts]);
   const clearError = () => {
@@ -293,7 +291,7 @@ const Form = ({
     const fieldName = Object.keys(errors)[0];
     const errorMessage = errors[fieldName];
     if (errorMessage) {
-      snackbar.showError(tTranslate(errorMessage, tOpts), null, "error");
+      snackbar.showError(errorMessage, null, "error");
     }
     const fieldConfig = model.columns.find(
       (column) => column.field === fieldName

--- a/src/lib/components/Form/Form.js
+++ b/src/lib/components/Form/Form.js
@@ -19,6 +19,7 @@ import PageTitle from "../PageTitle";
 import utils, { getPermissions } from "../utils";
 import Relations from "./relations";
 import { useModelTranslation } from "../../hooks/useModelTranslation";
+import { ERROR_CODES } from "../../errors";
 export const ActiveStepContext = createContext(1);
 const defaultFieldConfigs = {};
 const consts = {
@@ -139,7 +140,7 @@ const Form = ({
       });
       setActiveRecord(data);
     } catch (error) {
-      errorOnLoad('Could not load record', error.message);
+      errorOnLoad(error);
     } finally {
       setIsLoading(false);
     }
@@ -190,8 +191,8 @@ const Form = ({
           resetForm({ values: formik.values});
         })
         .catch((err) => {
-          snackbar.showError(
-            tTranslate("An error occurred, please try after some time.", tOpts),
+          snackbar.showErrorCode(
+            ERROR_CODES.AN_ERROR_OCCURRED,
             err
           );
           if (model.reloadOnSave) {
@@ -213,11 +214,11 @@ const Form = ({
     navigateBack !== false && handleNavigation();
   }, [formik, onCancel, navigateBack, handleNavigation]);
 
-  const errorOnLoad = useCallback((title, error) => {
+  const errorOnLoad = useCallback((error) => {
     setIsLoading(false);
-    snackbar.showError(tTranslate(title, tOpts), error);
+    snackbar.showErrorCode(ERROR_CODES.LOAD_FAILED, error?.message);
     handleNavigation();
-  }, [snackbar, handleNavigation, tTranslate, tOpts]);
+  }, [snackbar, handleNavigation]);
 
   const setActiveRecord = function ({ id, title, record, lookups }) {
     const isCopy = idWithOptions.indexOf("-") > -1;
@@ -268,7 +269,7 @@ const Form = ({
         navigateBack !== false && handleNavigation();
       }
     } catch (error) {
-      snackbar.showError(tTranslate("An error occurred, please try after some time.", tOpts), error?.message);
+      snackbar.showErrorCode(ERROR_CODES.AN_ERROR_OCCURRED, error?.message);
     } finally {
       setIsDeleting(false);
     }
@@ -300,7 +301,7 @@ const Form = ({
     if (fieldConfig.tab) {
       setActiveStep(Object.keys(model.tabs).indexOf(fieldConfig.tab));
     }
-  }, [beforeSubmit, formik, model, snackbar, setActiveStep, tTranslate, tOpts]);
+  }, [beforeSubmit, formik, model, snackbar, setActiveStep]);
 
   const breadcrumbs = [
     { text: tTranslate(formTitle, tOpts) },

--- a/src/lib/components/Form/Form.js
+++ b/src/lib/components/Form/Form.js
@@ -270,6 +270,8 @@ const Form = ({
       }
     } catch (error) {
       snackbar.showErrorCode(ERROR_CODES.DELETE_FAILED, error?.message);
+    } finally {
+      setIsDeleting(false);
     }
   }, [id, api, model.api, snackbar, setErrorMessage, model, navigateBack, handleNavigation, tTranslate, tOpts]);
   const clearError = () => {

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -823,7 +823,7 @@ const GridBase = memo(({
             path += `?${searchParams.toString()}`;
         }
         navigate(path);
-    }, [setActiveRecord, isStaticDataWithoutBackendApi, backendApi, model, parentFilters, where, pathname, addUrlParamKey, searchParams, navigate, getRecord, buildUrl, snackbar, tTranslate, tOpts]);
+    }, [setActiveRecord, isStaticDataWithoutBackendApi, backendApi, model, parentFilters, where, pathname, addUrlParamKey, searchParams, navigate, getRecord, buildUrl, snackbar]);
 
     const handleDownload = useCallback(({ documentLink }) => {
         if (!documentLink) return;

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -32,6 +32,7 @@ import Checkbox from '@mui/material/Checkbox';
 import { useModelTranslation } from '../../hooks/useModelTranslation';
 import { convertDefaultSort, areEqual, getDefaultOperator } from './helper';
 import { styled } from '@mui/material/styles';
+import { ERROR_CODES } from '../../errors';
 
 const defaultPageSize = 50;
 const sortRegex = /(\w+)( ASC| DESC)?/i;
@@ -280,7 +281,6 @@ const GridBase = memo(({
     const documentField = model.columns.find(ele => ele.type === 'fileUpload')?.field || "";
     const userDefinedPermissions = { add: effectivePermissions.add, edit: effectivePermissions.edit, delete: effectivePermissions.delete };
     const { canAdd, canEdit, canDelete } = getPermissions({ userData, model, userDefinedPermissions });
-    const tTranslate = useMemo(() => model.tTranslate ?? defaultTranslate, [model.tTranslate]);
     const { addUrlParamKey, searchParamKey, hideBreadcrumb = false, tableName, showHistory = true, hideBreadcrumbInGrid = false, breadcrumbColor, disablePivoting = false, columnHeaderHeight = 70, disablePagination = false } = model;
     const gridTitle = model.gridTitle || model.title;
     const preferenceKey = getApiEndpoint("GridPreferenceManager") ? (model.preferenceId || model.module?.preferenceId) : null;
@@ -786,7 +786,7 @@ const GridBase = memo(({
             }
         } catch (error) {
             if (error?.aborted || error?.name === 'AbortError' || controller?.signal?.aborted) return;
-            snackbar.showError(tTranslate('An error occurred while fetching data', tOpts));
+            snackbar.showErrorCode(ERROR_CODES.LOAD_FAILED, error?.message);
             if (!isExportRequest) {
                 setData((prevData) => ({ ...prevData, records: [], recordCount: 0 }));
             }
@@ -806,7 +806,7 @@ const GridBase = memo(({
                 const data = await getRecord({ id, api: baseUrl, model, parentFilters, where });
                 setActiveRecord(data);
             } catch (error) {
-                snackbar.showError(tTranslate('Could not load record', tOpts));
+                snackbar.showErrorCode(ERROR_CODES.LOAD_FAILED, error?.message);
             }
             return;
         }
@@ -913,7 +913,7 @@ const GridBase = memo(({
             snackbar.showMessage(tTranslate('Record Deleted Successfully.', tOpts));
             fetchData();
         } catch (error) {
-            snackbar.showError(tTranslate('Delete failed', tOpts), error.message);
+            snackbar.showErrorCode(ERROR_CODES.DELETE_FAILED, error?.message);
         } finally {
             setIsDeleting(false);
         }
@@ -959,7 +959,7 @@ const GridBase = memo(({
 
     const handleAddRecords = useCallback(async () => {
         if (rowSelectionModel.ids.size < 1) {
-            snackbar.showError(tTranslate("Please select at least one record to proceed", tOpts));
+            snackbar.showErrorCode(ERROR_CODES.SELECT_AT_LEAST_ONE);
             return;
         }
 
@@ -995,7 +995,7 @@ const GridBase = memo(({
                 snackbar.showMessage(message);
             }
         } catch (err) {
-            snackbar.showError(err.message || tTranslate('An error occurred, please try after some time.', tOpts));
+            snackbar.showErrorCode(ERROR_CODES.SAVE_FAILED, err?.message);
         } finally {
             setIsLoading(false);
             setRowSelectionModel({
@@ -1012,9 +1012,7 @@ const GridBase = memo(({
                 setShowAddConfirmation(true);
                 return;
             }
-            snackbar.showError(
-                tTranslate("Please select at least one record to proceed", tOpts),
-            );
+            snackbar.showErrorCode(ERROR_CODES.SELECT_AT_LEAST_ONE);
             return;
         }
         if (typeof onAddOverride === constants.function) {

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -792,7 +792,7 @@ const GridBase = memo(({
         } finally {
             if (!isExportRequest && fetchAbortControllerRef.current === controller) setIsLoading(false);
         }
-    }, [hasStaticData, normalizedStaticData, paginationModelForFetch, buildUrl, model, backendApi, filterModelForFetch, baseFilters, id, assigned, available, selected, props.extraParams, sortModelForFetch, stableGridColumns, parentFilters, onListParamsChange, apiRef, getList, snackbar, additionalFilters, tTranslate, tOpts]);
+    }, [hasStaticData, normalizedStaticData, paginationModelForFetch, buildUrl, model, backendApi, filterModelForFetch, baseFilters, id, assigned, available, selected, props.extraParams, sortModelForFetch, stableGridColumns, parentFilters, onListParamsChange, apiRef, getList, snackbar, additionalFilters]);
 
     const openForm = useCallback(async ({ id, record = {}, mode }) => {
         if (setActiveRecord) {

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -229,7 +229,7 @@ const GridBase = memo(({
     // Force client pagination when localSortAndFilter is enabled so that all data is
     // fetched in a single request and MUI DataGrid handles paging/sort/filter locally.
     const paginationMode = (hasStaticData || model.localSortAndFilter) ? constants.client : (model.paginationMode === constants.client ? constants.client : constants.server);
-    const { translate, tOpts } = useModelTranslation(model);
+    const { translate, tOpts, tTranslate } = useModelTranslation(model);
     const [errorMessage, setErrorMessage] = useState('');
     const [sortModel, setSortModel] = useState(convertDefaultSort(defaultSort || model.defaultSort, constants, sortRegex));
     const initialFilterModel = { items: [], logicOperator: 'and', quickFilterValues: Array(0), quickFilterLogicOperator: 'and' };
@@ -287,7 +287,6 @@ const GridBase = memo(({
     const searchParams = new URLSearchParams(window.location.search);
     const [currentPreference, setCurrentPreference] = useState(null);
     const [preferencesReady, setPreferencesReady] = useState(!preferenceKey);
-    const backendApiRequiredMessage = tTranslate('This action requires an API endpoint.', tOpts);
     // State for single expanded detail panel row
     const [rowPanelId, setRowPanelId] = useState(null);
     const detailPanelExpandedRowIds = useMemo(() => new Set(rowPanelId ? [rowPanelId] : []), [rowPanelId]);
@@ -786,7 +785,7 @@ const GridBase = memo(({
             }
         } catch (error) {
             if (error?.aborted || error?.name === 'AbortError' || controller?.signal?.aborted) return;
-            snackbar.showErrorCode(ERROR_CODES.LOAD_FAILED, error?.message);
+            snackbar.showErrorCode(ERROR_CODES.DATA_LOAD_FAILED, error?.message);
             if (!isExportRequest) {
                 setData((prevData) => ({ ...prevData, records: [], recordCount: 0 }));
             }
@@ -798,7 +797,7 @@ const GridBase = memo(({
     const openForm = useCallback(async ({ id, record = {}, mode }) => {
         if (setActiveRecord) {
             if (isStaticDataWithoutBackendApi) {
-                snackbar.showError(backendApiRequiredMessage);
+                snackbar.showErrorCode(ERROR_CODES.API_UNDEFINED);
                 return;
             }
             try {
@@ -824,7 +823,7 @@ const GridBase = memo(({
             path += `?${searchParams.toString()}`;
         }
         navigate(path);
-    }, [setActiveRecord, isStaticDataWithoutBackendApi, backendApi, backendApiRequiredMessage, model, parentFilters, where, pathname, addUrlParamKey, searchParams, navigate, getRecord, buildUrl, snackbar, tTranslate, tOpts]);
+    }, [setActiveRecord, isStaticDataWithoutBackendApi, backendApi, model, parentFilters, where, pathname, addUrlParamKey, searchParams, navigate, getRecord, buildUrl, snackbar, tTranslate, tOpts]);
 
     const handleDownload = useCallback(({ documentLink }) => {
         if (!documentLink) return;
@@ -904,7 +903,7 @@ const GridBase = memo(({
 
     const handleDelete = useCallback(async () => {
         if (isStaticDataWithoutBackendApi) {
-            snackbar.showError(backendApiRequiredMessage);
+            snackbar.showErrorCode(ERROR_CODES.API_UNDEFINED);
             return;
         }
         const baseUrl = buildUrl(backendApi);
@@ -917,7 +916,7 @@ const GridBase = memo(({
         } finally {
             setIsDeleting(false);
         }
-    }, [isStaticDataWithoutBackendApi, backendApiRequiredMessage, backendApi, record?.id, snackbar, model, fetchData, tTranslate, tOpts]);
+    }, [isStaticDataWithoutBackendApi, backendApi, record?.id, snackbar, model, fetchData, tTranslate, tOpts]);
 
     const clearError = useCallback(() => {
         setErrorMessage(null);
@@ -976,7 +975,7 @@ const GridBase = memo(({
 
         const apiEndpoint = selectionApi || backendApi;
         if (!apiEndpoint) {
-            snackbar.showError(backendApiRequiredMessage);
+            snackbar.showErrorCode(ERROR_CODES.API_UNDEFINED);
             return;
         }
         const baseUrl = buildUrl(apiEndpoint);
@@ -1004,7 +1003,7 @@ const GridBase = memo(({
             });
             setShowAddConfirmation(false);
         }
-    }, [rowSelectionModel.ids, snackbar, backendApiRequiredMessage, data.records, idProperty, baseSaveData, model.selectionUpdateKeys, selectionApi, backendApi, model, fetchData, tTranslate, tOpts]);
+    }, [rowSelectionModel.ids, snackbar, data.records, idProperty, baseSaveData, model.selectionUpdateKeys, selectionApi, backendApi, model, fetchData, tTranslate, tOpts]);
 
     const onAdd = useCallback(() => {
         if (selectionApi.length > 0) {

--- a/src/lib/components/Grid/ui-models.js
+++ b/src/lib/components/Grid/ui-models.js
@@ -142,7 +142,7 @@ class UiModel {
 		const validationConfig = {};
 		for (const column of columns) {
 			const { field, label, header, type = 'string', requiredIfNew = false, required = false, min = '', max = '', validate } = column;
-			const formLabel = label || header || field;
+			const formLabel = tTranslate(label || header || field, tOpts);
 			if (!formLabel) {
 				continue;
 			}

--- a/src/lib/components/Grid/ui-models.js
+++ b/src/lib/components/Grid/ui-models.js
@@ -48,7 +48,7 @@ const resolveValidationMessage = (rule, params, t) => {
 	const translated = typeof t === 'function'
 		? t(key, { defaultValue: template })
 		: template;
-	return utils.replaceTags(translated ?? template, params);
+	return utils.replaceTags(translated, params);
 };
 
 const emptyToNullTransform = (value, originalValue) => {

--- a/src/lib/components/Grid/ui-models.js
+++ b/src/lib/components/Grid/ui-models.js
@@ -212,7 +212,7 @@ class UiModel {
 						);
 					break;
 				case 'number':
-					config = yup.number().label(formLabel).nullable();
+					config = yup.number().nullable().transform(emptyToNullTransform).label(formLabel);
 					if (isValidNumericValue(min)) {
 						config = config.min(Number(min), resolveValidationMessage('minNumber', { label: formLabel, min }, t));
 					}

--- a/src/lib/components/Grid/ui-models.js
+++ b/src/lib/components/Grid/ui-models.js
@@ -30,15 +30,25 @@ const validationMessageTemplates = {
 const defaultValidationTranslationKeyPrefix = 'validation';
 
 /**
- * Resolves a validation message for a rule using either a caller-provided resolver
- * or the built-in template map.
+ * Resolves a validation message for a rule.
  *
- * @param {string} rule Validation rule key.
- * @param {Object} params Token map used to format the message.
+ * Builds the key `<defaultValidationTranslationKeyPrefix>.<rule>` and looks it
+ * up via the provided i18next `t` function with the built-in English template as
+ * the `defaultValue`. The resolved string is then processed through `replaceTags`
+ * to substitute any `${token}` placeholders from `params`.
+ *
+ * @param {string} rule Validation rule key (must exist in validationMessageTemplates).
+ * @param {Object} params Token map used to format the message (e.g. { label, min, max }).
+ * @param {Function} [t] Optional i18next t() function for i18n lookup.
  * @returns {string}
  */
-const resolveValidationMessage = (rule, params) => {
-	return utils.replaceTags(validationMessageTemplates[rule], params);
+const resolveValidationMessage = (rule, params, t) => {
+	const template = validationMessageTemplates[rule];
+	const key = `${defaultValidationTranslationKeyPrefix}.${rule}`;
+	const translated = typeof t === 'function'
+		? t(key, { defaultValue: template })
+		: template;
+	return utils.replaceTags(translated ?? template, params);
 };
 
 const emptyToNullTransform = (value, originalValue) => {
@@ -48,11 +58,11 @@ const emptyToNullTransform = (value, originalValue) => {
 
 const isValidNumericValue = (value) => value !== undefined && value !== '' && !isNaN(Number(value));
 
-const applyRequired = (config, label, shouldTrim = false) => {
+const applyRequired = (config, label, shouldTrim = false, t) => {
 	if (shouldTrim && typeof config.trim === 'function') {
-		return config.trim().required(resolveValidationMessage('required', { label }));
+		return config.trim().required(resolveValidationMessage('required', { label }, t));
 	}
-	return config.required(resolveValidationMessage('required', { label }));
+	return config.required(resolveValidationMessage('required', { label }, t));
 };
 
 const customStyle = {};
@@ -128,6 +138,8 @@ class UiModel {
 
 	getValidationSchema({ id, tTranslate = (key) => key, tOpts = {} } = {}) {
 		const { columns } = this;
+		const t = tOpts?.t;
+		const vm = (rule, params) => resolveValidationMessage(rule, params, t);
 		const validationConfig = {};
 		for (const column of columns) {
 			const { field, label, header, type = 'string', requiredIfNew = false, required = false, min = '', max = '', validate } = column;
@@ -141,10 +153,10 @@ class UiModel {
 				case 'string':
 					config = yup.string().nullable().trim().label(formLabel);
 					if (isValidNumericValue(min)) {
-						config = config.min(Number(min), resolveValidationMessage('minChars', { label: formLabel, min }));
+						config = config.min(Number(min), vm('minChars', { label: formLabel, min }));
 					}
 					if (isValidNumericValue(max)) {
-						config = config.max(Number(max), resolveValidationMessage('maxChars', { label: formLabel, max }));
+						config = config.max(Number(max), vm('maxChars', { label: formLabel, max }));
 					}
 					break;
 				case 'boolean':
@@ -174,7 +186,7 @@ class UiModel {
 				case 'password':
 					config = yup.string()
 						.label(formLabel)
-						.test("ignore-asterisks", resolveValidationMessage('passwordInvalid', { label: formLabel }), (value) => {
+						.test("ignore-asterisks", vm('passwordInvalid', { label: formLabel }), (value) => {
 							// Skip further validations if value is exactly "******"
 							if (value === "******") return true;
 							const minlength = Number(min) || 8;
@@ -182,11 +194,11 @@ class UiModel {
 							const regex = column.regex || regexConfig.password;
 							// Check minimum length, maximum length, and pattern if not "******"
 							return yup.string()
-								.min(minlength, resolveValidationMessage('minChars', { label: formLabel, min: minlength }))
-								.max(maxlength, resolveValidationMessage('maxChars', { label: formLabel, max: maxlength }))
+								.min(minlength, vm('minChars', { label: formLabel, min: minlength }))
+								.max(maxlength, vm('maxChars', { label: formLabel, max: maxlength }))
 								.matches(
 									regex,
-									resolveValidationMessage('passwordPolicy', { label: formLabel })
+									vm('passwordPolicy', { label: formLabel })
 								)
 								.isValidSync(value);
 						});
@@ -197,16 +209,16 @@ class UiModel {
 						.trim()
 						.matches(
 							(column.regex || regexConfig.email),
-							resolveValidationMessage('emailInvalid', { label: formLabel })
+							vm('emailInvalid', { label: formLabel })
 						);
 					break;
 				case 'number':
 					config = yup.number().label(formLabel).nullable();
 					if (isValidNumericValue(min)) {
-						config = config.min(Number(min), resolveValidationMessage('minNumber', { label: formLabel, min }));
+						config = config.min(Number(min), vm('minNumber', { label: formLabel, min }));
 					}
 					if (isValidNumericValue(max)) {
-						config = config.max(Number(max), resolveValidationMessage('maxNumber', { label: formLabel, max }));
+						config = config.max(Number(max), vm('maxNumber', { label: formLabel, max }));
 					}
 					break;
 				case 'fileUpload':
@@ -220,21 +232,21 @@ class UiModel {
 			// Apply required/requiredIfNew logic in one place
 			if (required) {
 				if (type === 'string') {
-					config = applyRequired(config, formLabel, true);
+					config = applyRequired(config, formLabel, true, t);
 				} else if (type === 'radio' || type === 'dayRadio') {
-					config = config.required(resolveValidationMessage('requiredSelectOption', { label: formLabel }));
+					config = config.required(vm('requiredSelectOption', { label: formLabel }));
 				} else if (type === 'date' || type === 'dateTime') {
-					config = config.required(resolveValidationMessage('required', { label: formLabel }));
+					config = config.required(vm('required', { label: formLabel }));
 				} else if (type === 'select' || type === 'autocomplete') {
-					config = config.required(resolveValidationMessage('requiredSelect', { label: formLabel }));
+					config = config.required(vm('requiredSelect', { label: formLabel }));
 				} else if (type === 'number') {
-					config = config.required(resolveValidationMessage('requiredNumber', { label: formLabel }));
+					config = config.required(vm('requiredNumber', { label: formLabel }));
 				} else {
-					config = applyRequired(config, formLabel);
+					config = applyRequired(config, formLabel, false, t);
 				}
 			}
 			if (requiredIfNew && (!id || id === '')) {
-				config = applyRequired(config, formLabel, type === 'string');
+				config = applyRequired(config, formLabel, type === 'string', t);
 			}
 			if (validate) {
 				const compareValidator = regexConfig.compareValidatorRegex.exec(validate);
@@ -245,7 +257,7 @@ class UiModel {
 					);
 					config = config.oneOf(
 						[yup.ref(compareFieldName)],
-						resolveValidationMessage('mustMatch', { label: formLabel, compareLabel: compareField?.label || compareFieldName })
+						vm('mustMatch', { label: formLabel, compareLabel: compareField?.label || compareFieldName })
 					);
 				}
 			}

--- a/src/lib/components/Grid/ui-models.js
+++ b/src/lib/components/Grid/ui-models.js
@@ -139,7 +139,6 @@ class UiModel {
 	getValidationSchema({ id, tTranslate = (key) => key, tOpts = {} } = {}) {
 		const { columns } = this;
 		const t = tOpts?.t;
-		const vm = (rule, params) => resolveValidationMessage(rule, params, t);
 		const validationConfig = {};
 		for (const column of columns) {
 			const { field, label, header, type = 'string', requiredIfNew = false, required = false, min = '', max = '', validate } = column;
@@ -153,10 +152,10 @@ class UiModel {
 				case 'string':
 					config = yup.string().nullable().trim().label(formLabel);
 					if (isValidNumericValue(min)) {
-						config = config.min(Number(min), vm('minChars', { label: formLabel, min }));
+						config = config.min(Number(min), resolveValidationMessage('minChars', { label: formLabel, min }, t));
 					}
 					if (isValidNumericValue(max)) {
-						config = config.max(Number(max), vm('maxChars', { label: formLabel, max }));
+						config = config.max(Number(max), resolveValidationMessage('maxChars', { label: formLabel, max }, t));
 					}
 					break;
 				case 'boolean':
@@ -186,7 +185,7 @@ class UiModel {
 				case 'password':
 					config = yup.string()
 						.label(formLabel)
-						.test("ignore-asterisks", vm('passwordInvalid', { label: formLabel }), (value) => {
+						.test("ignore-asterisks", resolveValidationMessage('passwordInvalid', { label: formLabel }, t), (value) => {
 							// Skip further validations if value is exactly "******"
 							if (value === "******") return true;
 							const minlength = Number(min) || 8;
@@ -194,11 +193,11 @@ class UiModel {
 							const regex = column.regex || regexConfig.password;
 							// Check minimum length, maximum length, and pattern if not "******"
 							return yup.string()
-								.min(minlength, vm('minChars', { label: formLabel, min: minlength }))
-								.max(maxlength, vm('maxChars', { label: formLabel, max: maxlength }))
+								.min(minlength, resolveValidationMessage('minChars', { label: formLabel, min: minlength }, t))
+								.max(maxlength, resolveValidationMessage('maxChars', { label: formLabel, max: maxlength }, t))
 								.matches(
 									regex,
-									vm('passwordPolicy', { label: formLabel })
+									resolveValidationMessage('passwordPolicy', { label: formLabel }, t)
 								)
 								.isValidSync(value);
 						});
@@ -209,16 +208,16 @@ class UiModel {
 						.trim()
 						.matches(
 							(column.regex || regexConfig.email),
-							vm('emailInvalid', { label: formLabel })
+							resolveValidationMessage('emailInvalid', { label: formLabel }, t)
 						);
 					break;
 				case 'number':
 					config = yup.number().label(formLabel).nullable();
 					if (isValidNumericValue(min)) {
-						config = config.min(Number(min), vm('minNumber', { label: formLabel, min }));
+						config = config.min(Number(min), resolveValidationMessage('minNumber', { label: formLabel, min }, t));
 					}
 					if (isValidNumericValue(max)) {
-						config = config.max(Number(max), vm('maxNumber', { label: formLabel, max }));
+						config = config.max(Number(max), resolveValidationMessage('maxNumber', { label: formLabel, max }, t));
 					}
 					break;
 				case 'fileUpload':
@@ -234,13 +233,13 @@ class UiModel {
 				if (type === 'string') {
 					config = applyRequired(config, formLabel, true, t);
 				} else if (type === 'radio' || type === 'dayRadio') {
-					config = config.required(vm('requiredSelectOption', { label: formLabel }));
+					config = config.required(resolveValidationMessage('requiredSelectOption', { label: formLabel }, t));
 				} else if (type === 'date' || type === 'dateTime') {
-					config = config.required(vm('required', { label: formLabel }));
+					config = config.required(resolveValidationMessage('required', { label: formLabel }, t));
 				} else if (type === 'select' || type === 'autocomplete') {
-					config = config.required(vm('requiredSelect', { label: formLabel }));
+					config = config.required(resolveValidationMessage('requiredSelect', { label: formLabel }, t));
 				} else if (type === 'number') {
-					config = config.required(vm('requiredNumber', { label: formLabel }));
+					config = config.required(resolveValidationMessage('requiredNumber', { label: formLabel }, t));
 				} else {
 					config = applyRequired(config, formLabel, false, t);
 				}
@@ -257,7 +256,7 @@ class UiModel {
 					);
 					config = config.oneOf(
 						[yup.ref(compareFieldName)],
-						vm('mustMatch', { label: formLabel, compareLabel: compareField?.label || compareFieldName })
+						resolveValidationMessage('mustMatch', { label: formLabel, compareLabel: compareField?.label || compareFieldName }, t)
 					);
 				}
 			}

--- a/src/lib/components/Grid/ui-models.js
+++ b/src/lib/components/Grid/ui-models.js
@@ -3,12 +3,56 @@ import React from 'react';
 import * as yup from 'yup';
 import { Divider } from '@mui/material';
 import Form from '../Form/Form';
+import utils from '../utils';
 
 const regexConfig = {
 	password: /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,50}$/,
 	nonAlphaNumeric: /[^a-zA-Z0-9]/g,
 	compareValidatorRegex: /^compare:(.+)$/,
 	email: /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/
+};
+
+const validationMessageTemplates = {
+	required: '${label}: required',
+	requiredSelectOption: '${label}: select at least one option',
+	requiredSelect: '${label}: select at least one',
+	minChars: '${label}: minimum ${min} characters',
+	maxChars: '${label}: maximum ${max} characters',
+	passwordInvalid: '${label}: invalid password',
+	passwordPolicy: '${label}: must contain lowercase, uppercase, digit, and special character',
+	emailInvalid: '${label}: invalid email format',
+	requiredNumber: '${label}: required',
+	minNumber: '${label}: minimum value is ${min}',
+	maxNumber: '${label}: maximum value is ${max}',
+	mustMatch: '${label}: must match ${compareLabel}'
+};
+
+const defaultValidationTranslationKeyPrefix = 'validation';
+
+/**
+ * Resolves a validation message for a rule using either a caller-provided resolver
+ * or the built-in template map.
+ *
+ * @param {string} rule Validation rule key.
+ * @param {Object} params Token map used to format the message.
+ * @returns {string}
+ */
+const resolveValidationMessage = (rule, params) => {
+	return utils.replaceTags(validationMessageTemplates[rule], params);
+};
+
+const emptyToNullTransform = (value, originalValue) => {
+	if (originalValue === '' || originalValue === null) return null;
+	return value;
+};
+
+const isValidNumericValue = (value) => value !== undefined && value !== '' && !isNaN(Number(value));
+
+const applyRequired = (config, label, shouldTrim = false) => {
+	if (shouldTrim && typeof config.trim === 'function') {
+		return config.trim().required(resolveValidationMessage('required', { label }));
+	}
+	return config.required(resolveValidationMessage('required', { label }));
 };
 
 const customStyle = {};
@@ -96,65 +140,41 @@ class UiModel {
 			switch (type) {
 				case 'string':
 					config = yup.string().nullable().trim().label(formLabel);
-					if (min && !isNaN(Number(min))) {
-						config = config.min(Number(min), tTranslate(`${formLabel} must be at least ${min} characters long`, tOpts));
+					if (isValidNumericValue(min)) {
+						config = config.min(Number(min), resolveValidationMessage('minChars', { label: formLabel, min }));
 					}
-					if (max && !isNaN(Number(max))) {
-						config = config.max(Number(max), tTranslate(`${formLabel} must be at most ${max} characters long`, tOpts));
-					}
-					if (required) {
-						config = config.trim().required(tTranslate(`${formLabel} is required`, tOpts));
+					if (isValidNumericValue(max)) {
+						config = config.max(Number(max), resolveValidationMessage('maxChars', { label: formLabel, max }));
 					}
 					break;
 				case 'boolean':
-					config = yup.bool().nullable().transform((value, originalValue) => {
-						if (originalValue === '') return null;
-						return value;
-					}).label(formLabel);
+					config = yup.bool().nullable().transform(emptyToNullTransform).label(formLabel);
 					break;
-
 				case 'radio':
 				case 'dayRadio':
-					config = yup.mixed().label(formLabel);
-					if (required) {
-						config = config.required(tTranslate(`Select at least one option for ${formLabel}`, tOpts));
-					}
+					config = yup.mixed().label(formLabel).nullable();
 					break;
 				case 'date':
-					config = yup.date().nullable().transform((value, originalValue) => {
-						if (originalValue === '' || originalValue === null) return null;
-						return value;
-					}).label(formLabel);
-					if (required) {
-						config = config.required(tTranslate(`${formLabel} is required`, tOpts));
-					}
+					config = yup.date().nullable().transform(emptyToNullTransform).label(formLabel);
 					break;
 				case 'dateTime':
 					config = yup
 						.date()
-						.nullable() // Allow null values
-						.transform((value, originalValue) => {
-							// Transform empty strings or null values into null
-							if (originalValue === '' || originalValue === null) return null;
-							return value;
-						})
-						.label(formLabel); // Set a label for better error messages
-					if (required) {
-						config = config.required(tTranslate(`${formLabel} is required`, tOpts));
-					}
+						.nullable()
+						.transform(emptyToNullTransform)
+						.label(formLabel);
 					break;
 				case 'select':
 				case 'autocomplete':
-					if (required) {
-						config = yup.string().trim().label(formLabel).required(tTranslate(`Select at least one ${formLabel}`, tOpts));
-					} else {
-						config = yup.string().nullable();
+					config = yup.string().trim().label(formLabel);
+					if (!required) {
+						config = config.nullable();
 					}
 					break;
 				case 'password':
 					config = yup.string()
 						.label(formLabel)
-						.test("ignore-asterisks", tTranslate(`${formLabel} must be a valid password.`, tOpts), (value) => {
+						.test("ignore-asterisks", resolveValidationMessage('passwordInvalid', { label: formLabel }), (value) => {
 							// Skip further validations if value is exactly "******"
 							if (value === "******") return true;
 							const minlength = Number(min) || 8;
@@ -162,11 +182,11 @@ class UiModel {
 							const regex = column.regex || regexConfig.password;
 							// Check minimum length, maximum length, and pattern if not "******"
 							return yup.string()
-								.min(minlength, tTranslate(`${formLabel} must be at least ${minlength} characters`, tOpts))
-								.max(maxlength, tTranslate(`${formLabel} must be at most ${maxlength} characters`, tOpts))
+								.min(minlength, resolveValidationMessage('minChars', { label: formLabel, min: minlength }))
+								.max(maxlength, resolveValidationMessage('maxChars', { label: formLabel, max: maxlength }))
 								.matches(
 									regex,
-									tTranslate(`${formLabel} must contain at least one lowercase letter, one uppercase letter, one digit, and one special character`, tOpts)
+									resolveValidationMessage('passwordPolicy', { label: formLabel })
 								)
 								.isValidSync(value);
 						});
@@ -177,20 +197,16 @@ class UiModel {
 						.trim()
 						.matches(
 							(column.regex || regexConfig.email),
-							tTranslate('Email must be a valid email', tOpts)
+							resolveValidationMessage('emailInvalid', { label: formLabel })
 						);
 					break;
 				case 'number':
-					if (required) {
-						config = yup.number().label(formLabel).required(tTranslate(`${formLabel} is required.`, tOpts));
-					} else {
-						config = yup.number().nullable();
+					config = yup.number().label(formLabel).nullable();
+					if (isValidNumericValue(min)) {
+						config = config.min(Number(min), resolveValidationMessage('minNumber', { label: formLabel, min }));
 					}
-					if (min !== undefined && min !== '' && !isNaN(Number(min))) {
-						config = config.min(Number(min), tTranslate(`${formLabel} must be greater than or equal to ${min}`, tOpts));
-					}
-					if (max !== undefined && max !== '' && !isNaN(Number(max))) {
-						config = config.max(Number(max), tTranslate(`${formLabel} must be less than or equal to ${max}`, tOpts));
+					if (isValidNumericValue(max)) {
+						config = config.max(Number(max), resolveValidationMessage('maxNumber', { label: formLabel, max }));
 					}
 					break;
 				case 'fileUpload':
@@ -200,11 +216,25 @@ class UiModel {
 					config = yup.mixed().nullable().label(formLabel);
 					break;
 			}
-			if (required && type !== "string") {
-				config = config.required(tTranslate(`${formLabel} is required`, tOpts));
+
+			// Apply required/requiredIfNew logic in one place
+			if (required) {
+				if (type === 'string') {
+					config = applyRequired(config, formLabel, true);
+				} else if (type === 'radio' || type === 'dayRadio') {
+					config = config.required(resolveValidationMessage('requiredSelectOption', { label: formLabel }));
+				} else if (type === 'date' || type === 'dateTime') {
+					config = config.required(resolveValidationMessage('required', { label: formLabel }));
+				} else if (type === 'select' || type === 'autocomplete') {
+					config = config.required(resolveValidationMessage('requiredSelect', { label: formLabel }));
+				} else if (type === 'number') {
+					config = config.required(resolveValidationMessage('requiredNumber', { label: formLabel }));
+				} else {
+					config = applyRequired(config, formLabel);
+				}
 			}
 			if (requiredIfNew && (!id || id === '')) {
-				config = config.trim().required(tTranslate(`${formLabel} is required`, tOpts));
+				config = applyRequired(config, formLabel, type === 'string');
 			}
 			if (validate) {
 				const compareValidator = regexConfig.compareValidatorRegex.exec(validate);
@@ -215,10 +245,9 @@ class UiModel {
 					);
 					config = config.oneOf(
 						[yup.ref(compareFieldName)],
-						tTranslate(`${formLabel} must match ${compareField.label}`, tOpts)
+						resolveValidationMessage('mustMatch', { label: formLabel, compareLabel: compareField?.label || compareFieldName })
 					);
 				}
-
 			}
 
 			validationConfig[field] = config;

--- a/src/lib/components/SnackBar/index.js
+++ b/src/lib/components/SnackBar/index.js
@@ -30,8 +30,7 @@ const SnackbarProvider = ({ children }) => {
     }, [showMessage]);
 
     const showErrorCode = useCallback((code, message, severity = "error", onAction) => {
-        const resolvedCode = typeof code !== 'string' ? String(code) : code;
-        const resolvedTitle = resolveErrorMessage(resolvedCode, t);
+        const resolvedTitle = resolveErrorMessage(code, t);
         showMessage(resolvedTitle, message, severity, onAction);
     }, [showMessage, t]);
 

--- a/src/lib/components/SnackBar/index.js
+++ b/src/lib/components/SnackBar/index.js
@@ -1,6 +1,8 @@
 import React, { useState, useContext, createContext, useCallback, useMemo } from 'react'
 import Snackbar from '@mui/material/Snackbar'
 import MuiAlert from '@mui/material/Alert';
+import { useTranslation } from 'react-i18next';
+import { resolveErrorMessage } from '../../errors';
 
 const SnackbarContext = createContext(null);
 const ANCHOR_ORIGIN = { vertical: 'bottom', horizontal: 'center' };
@@ -11,6 +13,8 @@ const Alert = React.forwardRef(function Alert(props, ref) {
 
 const SnackbarProvider = ({ children }) => {
     const [snack, setSnack] = useState({ open: false, message: null, severity: null, onAction: null });
+    const { t } = useTranslation();
+
 
     const showMessage = useCallback((title, message, severity = "info", onAction) => {
         const titleStr = typeof title === 'string' ? title : String(title);
@@ -25,13 +29,19 @@ const SnackbarProvider = ({ children }) => {
         showMessage(title, message, severity, onAction);
     }, [showMessage]);
 
+    const showErrorCode = useCallback((code, message, severity = "error", onAction) => {
+        const resolvedCode = typeof code !== 'string' ? String(code) : code;
+        const resolvedTitle = resolveErrorMessage(resolvedCode, t);
+        showMessage(resolvedTitle, message, severity, onAction);
+    }, [showMessage, t]);
+
     const handleClose = () => {
         const { onAction } = snack;
         setSnack(prev => ({ ...prev, open: false, onAction: null }));
         if (onAction) onAction();
     };
 
-    const contextValue = useMemo(() => ({ showMessage, showError }), [showMessage, showError]);
+    const contextValue = useMemo(() => ({ showMessage, showError, showErrorCode }), [showMessage, showError, showErrorCode]);
 
     return (
         <>

--- a/src/lib/components/utils.js
+++ b/src/lib/components/utils.js
@@ -1,3 +1,8 @@
+/**
+ * Matches placeholders like ${key} and ${group.key} in template strings.
+ */
+const defaultTemplate = /\$\{((\w+)\.)?(\w+)\}/gm;
+
 const utils = {
     filterFieldDataTypes: {
         Number: 'number',
@@ -40,6 +45,32 @@ const utils = {
         }
 
         return value ?? '';
+    },
+    
+    /**
+     * Replaces placeholders in a template string with values from a tag object.
+     *
+     * Supports single-level keys (${name}) and two-level keys (${user.name}).
+     *
+     * @param {string} source Template string containing placeholders.
+     * @param {Object} tags Value map used for placeholder replacement.
+     * @param {Object} [options] Optional replacement behavior.
+     * @param {RegExp} [options.template] Regex used to match placeholders.
+     * @param {boolean} [options.keepMissingTags=false] Keep unmatched placeholders as-is.
+     * @returns {string} Resolved string after replacement.
+     */
+    replaceTags: function (source, tags, { template = defaultTemplate, keepMissingTags = false } = {}) {
+        if (!source || !tags) {
+            return source;
+        }
+
+        return source.replace(template, function (match, _fullMatch, groupPrefix, key) {
+            const container = groupPrefix ? tags[groupPrefix] || {} : tags;
+            if (container[key] === undefined) {
+                return keepMissingTags ? match : "";
+            }
+            return container[key];
+        });
     }
 }
 export const getPermissions = ({ userData = {}, model, userDefinedPermissions }) => {

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,0 +1,104 @@
+/**
+ * Centralized error code registry.
+ *
+ * Each code is a stable, dot-namespaced key that can be used directly as an
+ * i18next translation key. Consuming applications add these keys to their
+ * translation files to override the default English messages in ERROR_MESSAGES.
+ *
+ * Pattern: error.<domain>_<verb>
+ */
+export const ERROR_CODES = {
+    // Session / access
+    SESSION_EXPIRED:        'error.session_expired',
+    ACCESS_DENIED:          'error.access_denied',
+
+    // Network / infrastructure
+    NETWORK_FAILURE:        'error.network_failure',
+    INTERNAL_SERVER_ERROR:  'error.internal_server_error',
+
+    // CRUD operations
+    LOAD_FAILED:            'error.load_failed',
+    SAVE_FAILED:            'error.save_failed',
+    DELETE_FAILED:          'error.delete_failed',
+    DELETE_NO_RECORD:       'error.delete_no_record',
+    LOOKUPS_FAILED:         'error.lookups_failed',
+
+    SELECT_AT_LEAST_ONE:    'error.select_at_least_one',
+
+    // Generic fallback
+    AN_ERROR_OCCURRED:      'error.an_error_occurred',
+    UNKNOWN:                'error.unknown',
+};
+
+/**
+ * Default English messages keyed by error code.
+ *
+ * These serve as the built-in fallback when the consuming application has not
+ * provided a translation for a given code. Place these keys in your i18next
+ * translation JSON to localize them.
+ *
+ * @example i18n translation file entry
+ *   {
+ *     "error": {
+ *       "save_failed": "Echec de l'enregistrement",
+ *       ...
+ *     }
+ *   }
+ */
+export const ERROR_MESSAGES = {
+    [ERROR_CODES.SESSION_EXPIRED]:       'Session Expired!',
+    [ERROR_CODES.ACCESS_DENIED]:         'Access Denied!',
+    [ERROR_CODES.NETWORK_FAILURE]:       'Network failure or server unreachable. Please try again.',
+    [ERROR_CODES.INTERNAL_SERVER_ERROR]: 'Internal Server Error',
+    [ERROR_CODES.LOAD_FAILED]:           'Could not load record',
+    [ERROR_CODES.SAVE_FAILED]:           'Save failed',
+    [ERROR_CODES.DELETE_FAILED]:         'Delete failed',
+    [ERROR_CODES.DELETE_NO_RECORD]:      'Delete failed. No active record.',
+    [ERROR_CODES.LOOKUPS_FAILED]:        'Could not load lookups',
+    [ERROR_CODES.AN_ERROR_OCCURRED]:     'An error occurred.',
+    [ERROR_CODES.UNKNOWN]:               'An unknown error occurred.',
+    [ERROR_CODES.SELECT_AT_LEAST_ONE]:   'Please select at least one record to proceed.'
+};
+
+/**
+ * Resolves an error code or plain string to a displayable message.
+ *
+ * When the consuming app supplies an i18next `t` function the error is
+ * translated; otherwise the built-in English message is used as a fallback.
+ *
+ * @param {string} codeOrMessage - An ERROR_CODES value or a plain message string.
+ * @param {Function} [t] - Optional i18next t() function from useTranslation().
+ * @returns {string}
+ */
+export const resolveErrorMessage = (codeOrMessage, t) => {
+    if (!codeOrMessage) return ERROR_MESSAGES[ERROR_CODES.UNKNOWN];
+    const fallback = ERROR_MESSAGES[codeOrMessage] ?? codeOrMessage;
+    if (typeof t === 'function') {
+        return t(codeOrMessage, { defaultValue: fallback });
+    }
+    return fallback;
+};
+
+/**
+ * Structured application error that pairs a stable error code with an optional
+ * server-supplied detail message and HTTP status.
+ *
+ * Using AppError instead of plain strings means callers receive a predictable
+ * shape regardless of which operation failed, and the display layer can
+ * translate the code independently of the service layer.
+ *
+ * @example
+ *   throw new AppError(ERROR_CODES.SAVE_FAILED, response.data.message, 200);
+ *
+ * @example
+ *   setError(new AppError(ERROR_CODES.NETWORK_FAILURE));
+ */
+export class AppError extends Error {
+    constructor(code, detail = null, httpStatus = null) {
+        super(ERROR_MESSAGES[code] ?? code);
+        this.name = 'AppError';
+        this.code = code;
+        this.detail = detail;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -77,10 +77,10 @@ export const ERROR_MESSAGES = {
  * @returns {string}
  */
 export const resolveErrorMessage = (codeOrMessage, t) => {
-    if (!codeOrMessage) return ERROR_MESSAGES[ERROR_CODES.UNKNOWN];
-    const fallback = ERROR_MESSAGES[codeOrMessage] ?? codeOrMessage;
+    const effectiveCode = codeOrMessage || ERROR_CODES.UNKNOWN;
+    const fallback = ERROR_MESSAGES[effectiveCode] ?? effectiveCode;
     if (typeof t === 'function') {
-        return t(codeOrMessage, { defaultValue: fallback });
+        return t(effectiveCode, { defaultValue: fallback });
     }
     return fallback;
 };

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -24,6 +24,10 @@ export const ERROR_CODES = {
     LOOKUPS_FAILED:         'error.lookups_failed',
 
     SELECT_AT_LEAST_ONE:    'error.select_at_least_one',
+    DATA_LOAD_FAILED:       'error.data_load_failed',
+
+    // API / configuration
+    API_UNDEFINED:          'error.api_undefined',
 
     // Generic fallback
     AN_ERROR_OCCURRED:      'error.an_error_occurred',
@@ -57,7 +61,9 @@ export const ERROR_MESSAGES = {
     [ERROR_CODES.LOOKUPS_FAILED]:        'Could not load lookups',
     [ERROR_CODES.AN_ERROR_OCCURRED]:     'An error occurred.',
     [ERROR_CODES.UNKNOWN]:               'An unknown error occurred.',
-    [ERROR_CODES.SELECT_AT_LEAST_ONE]:   'Please select at least one record to proceed.'
+    [ERROR_CODES.SELECT_AT_LEAST_ONE]:   'Please select at least one record to proceed.',
+    [ERROR_CODES.DATA_LOAD_FAILED]:      'Could not load data',
+    [ERROR_CODES.API_UNDEFINED]:         'This action requires an API endpoint.',
 };
 
 /**

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -78,8 +78,9 @@ export const ERROR_MESSAGES = {
  */
 export const resolveErrorMessage = (codeOrMessage, t) => {
     const effectiveCode = codeOrMessage || ERROR_CODES.UNKNOWN;
-    const fallback = ERROR_MESSAGES[effectiveCode] ?? effectiveCode;
-    if (typeof t === 'function') {
+    const isKnownCode = effectiveCode in ERROR_MESSAGES;
+    const fallback = isKnownCode ? ERROR_MESSAGES[effectiveCode] : effectiveCode;
+    if (isKnownCode && typeof t === 'function') {
         return t(effectiveCode, { defaultValue: fallback });
     }
     return fallback;
@@ -101,9 +102,10 @@ export const resolveErrorMessage = (codeOrMessage, t) => {
  */
 export class AppError extends Error {
     constructor(code, detail = null, httpStatus = null) {
-        super(ERROR_MESSAGES[code] ?? code);
+        const effectiveCode = code || ERROR_CODES.UNKNOWN;
+        super(ERROR_MESSAGES[effectiveCode] ?? effectiveCode);
         this.name = 'AppError';
-        this.code = code;
+        this.code = effectiveCode;
         this.detail = detail;
         this.httpStatus = httpStatus;
     }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -20,7 +20,7 @@ import useMobile from './components/useMobile';
 import httpRequest from './components/Grid/httpRequest';
 import crudHelper from './components/Grid/crud-helper';
 import { useModelTranslation } from './hooks/useModelTranslation';
-
+import { ERROR_CODES, ERROR_MESSAGES, AppError, resolveErrorMessage } from './errors';
 export { 
   SnackbarProvider,
   SnackbarContext,
@@ -47,5 +47,9 @@ export {
   useRouter,
   httpRequest,
   crudHelper,
-  useModelTranslation
+  useModelTranslation,
+  ERROR_CODES,
+  ERROR_MESSAGES,
+  AppError,
+  resolveErrorMessage
 };


### PR DESCRIPTION
Introduce a centralized error registry with fallback messages and a structured AppError to standardize error handling and translations. Provide a resolver and new snackbar API to show errors by code so UI can display localized or default messages consistently. Replace ad-hoc error strings with code-backed calls and expose error utilities from the library.

Also add a small template replacement util and standardized validation message templates/logic to produce consistent, tokenized validation messages and normalize empty-to-null transforms. Remove some stale translation deps from effect callbacks to reduce unnecessary dependencies and improve robustness.