### PR TITLE
Improves ISO date parsing for UTC and local handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework-ui",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "private": true,
   "type": "module",
   "main": "./index.js",

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -28,7 +28,7 @@ function shouldApplyFilter(filter) {
  * If false, supported UTC strings are interpreted as local wall-clock date/time.
  * @returns {*} - Returns the original value for non-string inputs, null for empty strings, a Date object for successfully parsed strings, the original string when parsing fails in the final non-UTC fallback branch, or an Invalid Date object in branches that directly return `new Date(...)` for an invalid date string.
  * @example
- * dateParser("20260413104406000", true);
+ * dateParser("20260413104406000", true); 
  * @example
  * dateParser("2026-04-13T10:44:06.000Z", false);
  */
@@ -62,10 +62,10 @@ const dateParser = (value, utc = false) => {
     }
 
     // Handle non-compact string inputs (including ISO-like formats)
-    if (utc) {
-        // Standard behavior: 'Z' suffix indicates UTC
-        return new Date(value);
-    }
+        if (utc) {
+            // Standard behavior: 'Z' suffix indicates UTC
+            return new Date(value);
+        }
 
     if (value.endsWith('Z')) {
         // Slice off the 'Z' to force the constructor to treat it as local time
@@ -219,9 +219,13 @@ const buildRequestData = ({ gridColumns, page, pageSize, sortModel, filterModel,
     const queryParams = new URLSearchParams();
     if (extraParams.template) {
         queryParams.append('template', extraParams.template);
+        // Delete template from requestData to avoid sending same info in both query params and body, which causes template to send as duplicate to server. Eg - "template-name, template-name"
+        delete requestData.template;
     }
     if (extraParams.configFileName) {
         queryParams.append('configFileName', extraParams.configFileName);
+        // Delete configFileName from requestData to avoid sending same info in both query params and body, which causes configFileName to send as duplicate to server. Eg - "config-file, config-file"
+        delete requestData.configFileName;
     }
     const queryString = queryParams.toString();
     if (queryString) {

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -61,7 +61,7 @@ const dateParser = (value, utc = false) => {
         return new Date(year, month, day, hour, min, sec, ms);
     }
 
-    // Handle "ISO" Format (YYYY-MM-DDTHH:mm:ss.SSSZ)
+    // Handle non-compact string inputs (including ISO-like formats)
     if (utc) {
         // Standard behavior: 'Z' suffix indicates UTC
         return new Date(value);

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -214,23 +214,23 @@ const buildRequestData = ({ gridColumns, page, pageSize, sortModel, filterModel,
         requestData.limitToSurveyed = model?.limitToSurveyed;
     }
 
-    let url = `${api}/${action}`;
+    const url = `${api}/${action}`;
 
-    const queryParams = new URLSearchParams();
-    if (extraParams.template) {
-        queryParams.append('template', extraParams.template);
-        // Delete template from requestData to avoid sending same info in both query params and body, which causes template to send as duplicate to server. Eg - "template-name, template-name"
-        delete requestData.template;
-    }
-    if (extraParams.configFileName) {
-        queryParams.append('configFileName', extraParams.configFileName);
-        // Delete configFileName from requestData to avoid sending same info in both query params and body, which causes configFileName to send as duplicate to server. Eg - "config-file, config-file"
-        delete requestData.configFileName;
-    }
-    const queryString = queryParams.toString();
-    if (queryString) {
-        url += `?${queryString}`;
-    }
+    // const queryParams = new URLSearchParams();
+    // if (extraParams.template) {
+    //     queryParams.append('template', extraParams.template);
+    //     // Delete template from requestData to avoid sending same info in both query params and body, which causes template to send as duplicate to server. Eg - "template-name, template-name"
+    //     delete requestData.template;
+    // }
+    // if (extraParams.configFileName) {
+    //     queryParams.append('configFileName', extraParams.configFileName);
+    //     // Delete configFileName from requestData to avoid sending same info in both query params and body, which causes configFileName to send as duplicate to server. Eg - "config-file, config-file"
+    //     delete requestData.configFileName;
+    // }
+    // const queryString = queryParams.toString();
+    // if (queryString) {
+    //     url += `?${queryString}`;
+    // }
 
     return { requestData, url, where, dateColumns };
 };

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -26,7 +26,7 @@ function shouldApplyFilter(filter) {
  *   - otherwise parses via `new Date(value)` and returns the original value if parsing is invalid
  * @param {boolean} [utc=false] - If true, preserves UTC-instant behavior for supported UTC inputs.
  * If false, supported UTC strings are interpreted as local wall-clock date/time.
- * @returns {*} - Returns a Date object for string inputs, the original value for non-string inputs, or null for empty strings.
+ * @returns {*} - Returns the original value for non-string inputs, null for empty strings, a Date object for successfully parsed strings, the original string when parsing fails in the final non-UTC fallback branch, or an Invalid Date object in branches that directly return `new Date(...)` for an invalid date string.
  * @example
  * dateParser("20260413104406000", true);
  * @example

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -22,7 +22,8 @@ function shouldApplyFilter(filter) {
  * - Compact: "YYYYMMDDHHmmssSSS" (e.g., "20260413104406000")
  * - Non-compact strings are parsed through the ISO branch:
  *   - `utc === true`: parsed via `new Date(value)`
- *   - `utc === false`: parses `new Date(value.slice(0, -1))` to treat `...Z` input as local wall-clock time
+ *   - `utc === false`: if the input ends with `Z`, parses `new Date(value.slice(0, -1))` to treat UTC input as local wall-clock time
+ *   - otherwise parses via `new Date(value)` and returns the original value if parsing is invalid
  * @param {boolean} [utc=false] - If true, preserves UTC-instant behavior for supported UTC inputs.
  * If false, supported UTC strings are interpreted as local wall-clock date/time.
  * @returns {*} - Returns a Date object for string inputs, the original value for non-string inputs, or null for empty strings.
@@ -65,10 +66,12 @@ const dateParser = (value, utc = false) => {
         // Standard behavior: 'Z' suffix indicates UTC
         return new Date(value);
     }
-    // Slice off the 'Z' to force the constructor to treat it as local time
-    return new Date(value.slice(0, -1));
 
-    // Fallback for other valid date formats (e.g. ISO without milliseconds, with offset)
+    if (value.endsWith('Z')) {
+        // Slice off the 'Z' to force the constructor to treat it as local time
+        return new Date(value.slice(0, -1));
+    }
+
     const parsedValue = new Date(value);
     return Number.isNaN(parsedValue.getTime()) ? value : parsedValue;
 };

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -16,24 +16,19 @@ function shouldApplyFilter(filter) {
 }
 
 /**
- * Parses a date string into a JavaScript Date object based on specific format lengths.
- * * @param {string} value - The date string to parse.
+ * Parses supported date strings into a JavaScript Date object.
+ * @param {string} value - The date string to parse.
  * Supported formats:
- * - 17 chars: "YYYYMMDDHHmmssSSS" (e.g., "20260413104406000")
- * - 24 chars: "YYYY-MM-DDTHH:mm:ss.SSSZ" (e.g., "2026-04-13T10:44:06.000Z")
- * @param {boolean} [utc=false] - If true, treats the input as UTC and returns a localized Date.
- * If false, treats input as local time (for 17-char) or 
- * strips the 'Z' (for 24-char) to treat as local.
- * @returns {Date|string|null} - Returns a Date object, the original value if not a string, or null if empty.
- * @throws {Error} - Throws error if the string length is not 17 or 24.
- * * @example
- * // Length 17: Treat as UTC and convert to local
- * // Input: "20260413104406000"
- * dateParser("20260413104406000", true); 
- * * @example
- * // Length 24: ISO format
- * // Input: "2026-04-13T10:44:06.000Z"
- * dateParser("2026-04-13T10:44:06.000Z", true);
+ * - Compact: "YYYYMMDDHHmmssSSS" (e.g., "20260413104406000")
+ * - ISO UTC: "YYYY-MM-DDTHH:mm:ssZ" or "YYYY-MM-DDTHH:mm:ss.S...Z" (e.g., "2026-04-13T10:44:06Z", "2026-04-13T10:44:06.000123Z")
+ * - Any other value parseable by `new Date(value)` (fallback path)
+ * @param {boolean} [utc=false] - If true, preserves UTC-instant behavior for supported UTC inputs.
+ * If false, supported UTC strings are interpreted as local wall-clock date/time.
+ * @returns {Date|string|null} - Returns a Date object, the original value if not a string/unparseable, or null if empty.
+ * @example
+ * dateParser("20260413104406000", true);
+ * @example
+ * dateParser("2026-04-13T10:44:06.000Z", false);
  */
 const dateParser = (value, utc = false) => {
     // Validation: Return original value if it's not a string or is undefined/null

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -216,22 +216,6 @@ const buildRequestData = ({ gridColumns, page, pageSize, sortModel, filterModel,
 
     const url = `${api}/${action}`;
 
-    // const queryParams = new URLSearchParams();
-    // if (extraParams.template) {
-    //     queryParams.append('template', extraParams.template);
-    //     // Delete template from requestData to avoid sending same info in both query params and body, which causes template to send as duplicate to server. Eg - "template-name, template-name"
-    //     delete requestData.template;
-    // }
-    // if (extraParams.configFileName) {
-    //     queryParams.append('configFileName', extraParams.configFileName);
-    //     // Delete configFileName from requestData to avoid sending same info in both query params and body, which causes configFileName to send as duplicate to server. Eg - "config-file, config-file"
-    //     delete requestData.configFileName;
-    // }
-    // const queryString = queryParams.toString();
-    // if (queryString) {
-    //     url += `?${queryString}`;
-    // }
-
     return { requestData, url, where, dateColumns };
 };
 

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -18,13 +18,14 @@ function shouldApplyFilter(filter) {
 /**
  * Parses supported date strings into a JavaScript Date object.
  * @param {*} value - The input value to parse as a date when it is a string.
- * Supported formats:
+ * Supported handling:
  * - Compact: "YYYYMMDDHHmmssSSS" (e.g., "20260413104406000")
- * - ISO UTC: "YYYY-MM-DDTHH:mm:ssZ" or "YYYY-MM-DDTHH:mm:ss.S...Z" (e.g., "2026-04-13T10:44:06Z", "2026-04-13T10:44:06.000123Z")
- * - Any other value parseable by `new Date(value)` (fallback path)
+ * - Non-compact strings are parsed through the ISO branch:
+ *   - `utc === true`: parsed via `new Date(value)`
+ *   - `utc === false`: parses `new Date(value.slice(0, -1))` to treat `...Z` input as local wall-clock time
  * @param {boolean} [utc=false] - If true, preserves UTC-instant behavior for supported UTC inputs.
  * If false, supported UTC strings are interpreted as local wall-clock date/time.
- * @returns {*} - Returns a Date object for parseable strings, the original value when non-string/unparseable, or null for empty strings.
+ * @returns {*} - Returns a Date object for string inputs, the original value for non-string inputs, or null for empty strings.
  * @example
  * dateParser("20260413104406000", true);
  * @example

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -65,13 +65,18 @@ const dateParser = (value, utc = false) => {
     }
 
     // Handle "ISO" Format (YYYY-MM-DDTHH:mm:ss.SSSZ)
-    if (value.length === 24) {
+    const isoUtcMatch = value.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z$/);
+    if (isoUtcMatch) {
+        const [, base, fraction = ''] = isoUtcMatch;
+        const milliseconds = fraction ? fraction.slice(0, 3).padEnd(3, '0') : '';
+        const normalizedValue = milliseconds ? `${base}.${milliseconds}Z` : `${base}Z`;
+
         if (utc) {
-            // Standard behavior: 'Z' suffix indicates UTC
-            return new Date(value);
+            // Parse as UTC instant and let the UI localize when needed.
+            return new Date(normalizedValue);
         }
-        // Slice off the 'Z' to force the constructor to treat it as local time
-        return new Date(value.slice(0, -1));
+        // Drop timezone marker so localize=false preserves source wall-clock date/time.
+        return new Date(normalizedValue.slice(0, -1));
     }
 
     // Fallback for other valid date formats (e.g. ISO without milliseconds, with offset)

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -75,7 +75,7 @@ const dateParser = (value, utc = false) => {
             // Parse as UTC instant and let the UI localize when needed.
             return new Date(normalizedValue);
         }
-        // Drop timezone marker so localize=false preserves source wall-clock date/time.
+        // Drop the timezone marker so utc === false preserves the source wall-clock date/time.
         return new Date(normalizedValue.slice(0, -1));
     }
 

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -17,14 +17,14 @@ function shouldApplyFilter(filter) {
 
 /**
  * Parses supported date strings into a JavaScript Date object.
- * @param {string} value - The date string to parse.
+ * @param {*} value - The input value to parse as a date when it is a string.
  * Supported formats:
  * - Compact: "YYYYMMDDHHmmssSSS" (e.g., "20260413104406000")
  * - ISO UTC: "YYYY-MM-DDTHH:mm:ssZ" or "YYYY-MM-DDTHH:mm:ss.S...Z" (e.g., "2026-04-13T10:44:06Z", "2026-04-13T10:44:06.000123Z")
  * - Any other value parseable by `new Date(value)` (fallback path)
  * @param {boolean} [utc=false] - If true, preserves UTC-instant behavior for supported UTC inputs.
  * If false, supported UTC strings are interpreted as local wall-clock date/time.
- * @returns {Date|string|null} - Returns a Date object, the original value if not a string/unparseable, or null if empty.
+ * @returns {*} - Returns a Date object for parseable strings, the original value when non-string/unparseable, or null for empty strings.
  * @example
  * dateParser("20260413104406000", true);
  * @example
@@ -59,7 +59,7 @@ const dateParser = (value, utc = false) => {
         return new Date(year, month, day, hour, min, sec, ms);
     }
 
-    // Handle "ISO" Format (YYYY-MM-DDTHH:mm:ss.SSSZ)
+    // Handle "ISO" Format (YYYY-MM-DDTHH:mm:ssZ or YYYY-MM-DDTHH:mm:ss.S...Z)
     const isoUtcMatch = value.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z$/);
     if (isoUtcMatch) {
         const [, base, fraction = ''] = isoUtcMatch;

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -59,20 +59,13 @@ const dateParser = (value, utc = false) => {
         return new Date(year, month, day, hour, min, sec, ms);
     }
 
-    // Handle "ISO" Format (YYYY-MM-DDTHH:mm:ssZ or YYYY-MM-DDTHH:mm:ss.S...Z)
-    const isoUtcMatch = value.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d+))?Z$/);
-    if (isoUtcMatch) {
-        const [, base, fraction = ''] = isoUtcMatch;
-        const milliseconds = fraction ? fraction.slice(0, 3).padEnd(3, '0') : '';
-        const normalizedValue = milliseconds ? `${base}.${milliseconds}Z` : `${base}Z`;
-
-        if (utc) {
-            // Parse as UTC instant and let the UI localize when needed.
-            return new Date(normalizedValue);
-        }
-        // Drop the timezone marker so utc === false preserves the source wall-clock date/time.
-        return new Date(normalizedValue.slice(0, -1));
+    // Handle "ISO" Format (YYYY-MM-DDTHH:mm:ss.SSSZ)
+    if (utc) {
+        // Standard behavior: 'Z' suffix indicates UTC
+        return new Date(value);
     }
+    // Slice off the 'Z' to force the constructor to treat it as local time
+    return new Date(value.slice(0, -1));
 
     // Fallback for other valid date formats (e.g. ISO without milliseconds, with offset)
     const parsedValue = new Date(value);

--- a/src/lib/components/Grid/crud-helper.js
+++ b/src/lib/components/Grid/crud-helper.js
@@ -62,10 +62,10 @@ const dateParser = (value, utc = false) => {
     }
 
     // Handle non-compact string inputs (including ISO-like formats)
-        if (utc) {
-            // Standard behavior: 'Z' suffix indicates UTC
-            return new Date(value);
-        }
+    if (utc) {
+        // Standard behavior: 'Z' suffix indicates UTC
+        return new Date(value);
+    }
 
     if (value.endsWith('Z')) {
         // Slice off the 'Z' to force the constructor to treat it as local time


### PR DESCRIPTION
This pull request primarily updates the date parsing logic in the `dateParser` utility function to better handle various date string formats, improves the clarity of its documentation, and makes a minor version bump in the package. The changes also simplify the URL construction logic in the request data builder. The most important changes are:

**Date Parsing Improvements:**

* Enhanced the `dateParser` function in `crud-helper.js` to more robustly handle both compact and ISO-like date string formats, including correct UTC and local time interpretations, and improved fallback behavior for invalid inputs.
* Rewrote and clarified the documentation for `dateParser` to accurately reflect its supported formats, behaviors, and return values, making it easier for developers to understand how to use the function.

**Request Data Construction:**

* Simplified the URL construction logic in the `buildRequestData` function by removing unnecessary query parameter handling, resulting in a cleaner and more maintainable implementation.

**Version Update:**

* Bumped the package version from `2.0.19` to `2.0.20` in `package.json` to reflect these changes.