### PR TITLE
Fix validation key casing and handle zero-value for required select fields

### DIFF
--- a/src/lib/components/Grid/ui-models.js
+++ b/src/lib/components/Grid/ui-models.js
@@ -44,7 +44,7 @@ const defaultValidationTranslationKeyPrefix = 'validation';
  */
 const resolveValidationMessage = (rule, params, t) => {
 	const template = validationMessageTemplates[rule];
-	const key = `${defaultValidationTranslationKeyPrefix}.${rule}`;
+	const key = `${defaultValidationTranslationKeyPrefix}.${rule}`.toLowerCase();
 	const translated = typeof t === 'function'
 		? t(key, { defaultValue: template })
 		: template;
@@ -177,7 +177,10 @@ class UiModel {
 					break;
 				case 'select':
 				case 'autocomplete':
-					config = yup.string().trim().label(formLabel);
+					config = yup.string().transform((value, originalValue) => {
+							if (originalValue === 0 || originalValue === '0') return '';
+							return value;
+						}).trim().label(formLabel);
 					if (!required) {
 						config = config.nullable();
 					}

--- a/src/lib/components/Grid/ui-models.js
+++ b/src/lib/components/Grid/ui-models.js
@@ -178,9 +178,9 @@ class UiModel {
 				case 'select':
 				case 'autocomplete':
 					config = yup.string().transform((value, originalValue) => {
-							if (originalValue === 0 || originalValue === '0') return '';
-							return value;
-						}).trim().label(formLabel);
+						if (originalValue === 0 || originalValue === '0') return '';
+						return value;
+					}).trim().label(formLabel);
 					if (!required) {
 						config = config.nullable();
 					}


### PR DESCRIPTION
1. Normalize select/autocomplete zero values — Added a yup transform to convert 0 or '0' to empty string for select/autocomplete field validation. This ensures required select fields correctly fail validation when the selected value is 0 (which was previously treated as a valid selection). 
2. Lowercase validation translation key — Added .toLowerCase() to the i18n key resolution in resolveValidationMessage to ensure consistent key lookups regardless of rule name casing.