### PR TITLE
#67145 - Added logic to pin detail panel toggle and fixed row selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework-ui",
-  "version": "2.0.19",
+  "version": "2.0.21",
   "private": true,
   "type": "module",
   "main": "./index.js",

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -1446,6 +1446,11 @@ const GridBase = memo(({
                                 "& .MuiDataGrid-virtualScroller ": {
                                     zIndex: 2
                                 },
+                                ...(model.showDetailPanelColumn === false && {
+                                    '& .MuiDataGrid-cell[data-field="__detail_panel_toggle__"], & .MuiDataGrid-columnHeader[data-field="__detail_panel_toggle__"]': {
+                                        display: 'none'
+                                    }
+                                }),
                             },
                             ...(Array.isArray(propsSx) ? propsSx : propsSx ? [propsSx] : [])
                         ]}

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -641,6 +641,11 @@ const GridBase = memo(({
 
             pinnedColumns.right.push('actions');
         }
+        // Pin detail panel toggle to the configured side when it has per-row visibility control
+        if (typeof model.getDetailPanelContent === 'function' && model.getDetailPanelContent) {
+            const togglePos = model?.detailTogglePosition || constants.left;
+            pinnedColumns[togglePos].push('__detail_panel_toggle__');
+        }
         return { stableGridColumns: finalColumns, pinnedColumns, lookupMap };
     }, [columns, model, parent, permissions, forAssignment, dynamicColumns, translate, stateData?.dateTime, groupingModel]);
 
@@ -1028,6 +1033,32 @@ const GridBase = memo(({
         if (!filterModel?.items?.length) return;
         setFilterModel({ ...constants.gridFilterModel });
     }, [filterModel]);
+
+     /**
+     * Gets the selected row IDs from the grid based on the current selection state.
+     * Handles both 'include' (selected rows) and 'exclude' (all rows except excluded) selection types.
+     * @returns {Array} Array of selected row IDs
+     */
+    const getSelectedRowIds =((selectionModel) => {
+        const selection = selectionModel || apiRef.current?.state?.rowSelection || { type: 'include', ids: new Set() };
+        const allRowIds = apiRef.current ? apiRef.current.getAllRowIds() : [];
+        if (selection.type === 'include') {
+            return Array.from(selection.ids || []);
+        }
+        // exclude = all rows except excluded
+        return allRowIds.filter(id => !(selection.ids || new Set()).has(id));
+    });
+
+    const handleRowSelectionModelChange = useCallback((selectionModel) => {
+        let normalizedModel = selectionModel;
+        if (selectionModel.type === 'exclude') {
+            const selectedIds = getSelectedRowIds(selectionModel);
+            normalizedModel = { type: 'include', ids: new Set(selectedIds) };
+        }
+        setRowSelectionModel(normalizedModel);
+        props.onRowSelectionModelChange?.(normalizedModel);
+    }, [getSelectedRowIds, props.onRowSelectionModelChange]);
+    
     const updateAssignment = useCallback(({ unassign, assign }) => {
         const assignedValues = Array.isArray(selected) ? selected : (selected.length ? selected.split(',') : []);
         const finalValues = unassign ? assignedValues.filter(id => !unassign.includes(parseInt(id))) : [...assignedValues, ...assign];
@@ -1415,15 +1446,12 @@ const GridBase = memo(({
                                 "& .MuiDataGrid-virtualScroller ": {
                                     zIndex: 2
                                 },
-                                "& .MuiDataGrid-detailPanelToggleCell, & .MuiDataGrid-cell--withRenderer.MuiDataGrid-cell--detailPanelToggle": {
-                                    display: 'none'
-                                },
                             },
                             ...(Array.isArray(propsSx) ? propsSx : propsSx ? [propsSx] : [])
                         ]}
                         headerFilters={showHeaderFilters}
                         unstable_headerFilters={showHeaderFilters} //for older versions of mui
-                        checkboxSelection={forAssignment}
+                        checkboxSelection={forAssignment || !!model.checkboxSelection}
                         loading={!data.records || isLoading}
                         className="pagination-fix"
                         onCellClick={onCellClickHandler}
@@ -1444,7 +1472,7 @@ const GridBase = memo(({
                         onSortModelChange={updateSort}
                         onFilterModelChange={updateFilters}
                         rowSelectionModel={rowSelectionModel}
-                        onRowSelectionModelChange={setRowSelectionModel}
+                        onRowSelectionModelChange={handleRowSelectionModelChange}
                         filterModel={filterModel}
                         getRowId={getGridRowId}
                         onRowClick={onRowClick}


### PR DESCRIPTION
Added logic to pin detail panel toggle to the configured side when per-row visibility control exists. The toggle position is extracted from model.detailTogglePosition or defaults to constants.left.
Implemented getSelectedRowIds utility function to handle both 'include' (selected rows) and 'exclude' (all rows except excluded) selection types, providing consistent row ID resolution.
Added handleRowSelectionModelChange callback that normalizes selection models by converting 'exclude' type selections to 'include' type before updating state and invoking the onRowSelectionModelChange prop.
Enhanced checkbox selection logic to respect model.checkboxSelection configuration in addition to the forAssignment flag.
Removed CSS display:none rules for detail panel toggle cells to allow proper rendering based on the new pinning configuration.

Added conditional styling to hide the detail panel toggle column when model.showDetailPanelColumn is false. The styles target both the cell and column header elements with the "__detail_panel_toggle__" field identifier and apply display: none to completely hide the detail panel toggle UI element based on configuration.