### PR TITLE
#67145 - improve detail panel toggle positioning and row selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework-ui",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "private": true,
   "type": "module",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework-ui",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "private": true,
   "type": "module",
   "main": "./index.js",

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -644,7 +644,7 @@ const GridBase = memo(({
         }
         if (enableRowDetailPanel && model.detailPanelTogglePosition === constants.right) pinnedColumns.right.push('__detail_panel_toggle__');
         return { stableGridColumns: finalColumns, pinnedColumns, lookupMap };
-    }, [columns, model, parent, permissions, forAssignment, dynamicColumns, translate, stateData?.dateTime, groupingModel]);
+    }, [columns, model, parent, permissions, forAssignment, dynamicColumns, translate, stateData?.dateTime, groupingModel, enableRowDetailPanel]);
 
     // Shallow-copy columns when lookups change so MUI DataGrid's GridFilterInputSingleSelect
     // sees new column object references and re-evaluates its memoized currentValueOptions.
@@ -1042,7 +1042,7 @@ const GridBase = memo(({
         }
         // exclude = all rows except excluded
         return allRowIds.filter(id => !(selection.ids || new Set()).has(id));
-    }, []);
+    }, [apiRef]);
 
     const handleRowSelectionModelChange = useCallback((selectionModel) => {
         let normalizedModel = selectionModel;

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -640,6 +640,11 @@ const GridBase = memo(({
 
             pinnedColumns.right.push('actions');
         }
+        // Pin detail panel toggle to the configured side when it has per-row visibility control
+        if (typeof model.getDetailPanelContent === 'function') {
+            const togglePos = model?.detailTogglePosition || constants.left;
+            pinnedColumns[togglePos].push('__detail_panel_toggle__');
+        }
         return { stableGridColumns: finalColumns, pinnedColumns, lookupMap };
     }, [columns, model, parent, permissions, forAssignment, dynamicColumns, translate, stateData?.dateTime, groupingModel]);
 
@@ -1025,6 +1030,33 @@ const GridBase = memo(({
         if (!filterModel?.items?.length) return;
         setFilterModel({ ...constants.gridFilterModel });
     }, [filterModel]);
+
+    /**
+     * Gets the selected row IDs from the grid based on the current selection state.
+     * Handles both 'include' (selected rows) and 'exclude' (all rows except excluded) selection types.
+     * @returns {Array} Array of selected row IDs
+     */
+    const getSelectedRowIds = useCallback((selectionModel) => {
+        const selection = selectionModel || apiRef.current?.state?.rowSelection || { type: 'include', ids: new Set() };
+        const allRowIds = apiRef.current ? apiRef.current.getAllRowIds() : [];
+        if (selection.type === 'include') {
+            return Array.from(selection.ids || []);
+        }
+        // exclude = all rows except excluded
+        return allRowIds.filter(id => !(selection.ids || new Set()).has(id));
+    }, []);
+
+    const handleRowSelectionModelChange = useCallback((selectionModel) => {
+        let normalizedModel = selectionModel;
+        if (selectionModel.type === 'exclude') {
+            const selectedIds = getSelectedRowIds(selectionModel);
+            normalizedModel = { type: 'include', ids: new Set(selectedIds) };
+        }
+        setRowSelectionModel(normalizedModel);
+        props.onRowSelectionModelChange?.(normalizedModel);
+    }, [getSelectedRowIds, props.onRowSelectionModelChange]);
+    
+
     const updateAssignment = useCallback(({ unassign, assign }) => {
         const assignedValues = Array.isArray(selected) ? selected : (selected.length ? selected.split(',') : []);
         const finalValues = unassign ? assignedValues.filter(id => !unassign.includes(parseInt(id))) : [...assignedValues, ...assign];
@@ -1412,15 +1444,17 @@ const GridBase = memo(({
                                 "& .MuiDataGrid-virtualScroller ": {
                                     zIndex: 2
                                 },
-                                "& .MuiDataGrid-detailPanelToggleCell, & .MuiDataGrid-cell--withRenderer.MuiDataGrid-cell--detailPanelToggle": {
-                                    display: 'none'
-                                },
+                                ...(model.showDetailPanelColumn === false && {
+                                    '& .MuiDataGrid-cell[data-field="__detail_panel_toggle__"], & .MuiDataGrid-columnHeader[data-field="__detail_panel_toggle__"]': {
+                                        display: 'none'
+                                    }
+                                }),
                             },
                             ...(Array.isArray(propsSx) ? propsSx : propsSx ? [propsSx] : [])
                         ]}
                         headerFilters={showHeaderFilters}
                         unstable_headerFilters={showHeaderFilters} //for older versions of mui
-                        checkboxSelection={forAssignment}
+                        checkboxSelection={forAssignment || !!model.checkboxSelection}
                         loading={!data.records || isLoading}
                         className="pagination-fix"
                         onCellClick={onCellClickHandler}
@@ -1441,7 +1475,7 @@ const GridBase = memo(({
                         onSortModelChange={updateSort}
                         onFilterModelChange={updateFilters}
                         rowSelectionModel={rowSelectionModel}
-                        onRowSelectionModelChange={setRowSelectionModel}
+                        onRowSelectionModelChange={handleRowSelectionModelChange}
                         filterModel={filterModel}
                         getRowId={getGridRowId}
                         onRowClick={onRowClick}

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -291,6 +291,8 @@ const GridBase = memo(({
     const [rowPanelId, setRowPanelId] = useState(null);
     const detailPanelExpandedRowIds = useMemo(() => new Set(rowPanelId ? [rowPanelId] : []), [rowPanelId]);
     const enableRowDetailPanel = typeof model.getDetailPanelContent === 'function';
+    const gridRows = useMemo(() => data.records || [], [data.records]);
+    const rowCount = useMemo(() => data.recordCount, [data.recordCount]);
     const [groupingModel, setGroupingModel] = useState([]);
 
     useEffect(() => {
@@ -640,11 +642,7 @@ const GridBase = memo(({
 
             pinnedColumns.right.push('actions');
         }
-        // Pin detail panel toggle to the configured side when it has per-row visibility control
-        if (typeof model.getDetailPanelContent === 'function') {
-            const togglePos = model?.detailTogglePosition || constants.left;
-            pinnedColumns[togglePos].push('__detail_panel_toggle__');
-        }
+        if (enableRowDetailPanel && model.detailPanelTogglePosition === constants.right) pinnedColumns.right.push('__detail_panel_toggle__');
         return { stableGridColumns: finalColumns, pinnedColumns, lookupMap };
     }, [columns, model, parent, permissions, forAssignment, dynamicColumns, translate, stateData?.dateTime, groupingModel]);
 
@@ -1426,6 +1424,10 @@ const GridBase = memo(({
         footer: Footer
     }), []);
 
+    const gridSxProps = useMemo(() => [
+        ...(Array.isArray(propsSx) ? propsSx : propsSx ? [propsSx] : [])
+    ], [propsSx]);
+
     return (
         <>
             {showPageTitle !== false && <PageTitle navigate={navigate} showBreadcrumbs={!hideBreadcrumb && !hideBreadcrumbInGrid}
@@ -1433,25 +1435,7 @@ const GridBase = memo(({
             <Box style={gridStyle || customStyle}>
                 <Box sx={{ display: 'flex', maxHeight: '80vh', flexDirection: 'column' }}>
                     <DataGridPremium
-                        sx={[
-                            {
-                                "& .MuiTablePagination-selectLabel": {
-                                    marginTop: 2
-                                },
-                                "& .MuiTablePagination-displayedRows": {
-                                    marginTop: 2
-                                },
-                                "& .MuiDataGrid-virtualScroller ": {
-                                    zIndex: 2
-                                },
-                                ...(model.showDetailPanelColumn === false && {
-                                    '& .MuiDataGrid-cell[data-field="__detail_panel_toggle__"], & .MuiDataGrid-columnHeader[data-field="__detail_panel_toggle__"]': {
-                                        display: 'none'
-                                    }
-                                }),
-                            },
-                            ...(Array.isArray(propsSx) ? propsSx : propsSx ? [propsSx] : [])
-                        ]}
+                        sx={gridSxProps}
                         headerFilters={showHeaderFilters}
                         unstable_headerFilters={showHeaderFilters} //for older versions of mui
                         checkboxSelection={forAssignment || !!model.checkboxSelection}
@@ -1464,8 +1448,8 @@ const GridBase = memo(({
                         pageSizeOptions={constants.pageSizeOptions}
                         onPaginationModelChange={setPaginationModel}
                         pagination={!disablePagination}
-                        rowCount={data.recordCount}
-                        rows={data.records || []}
+                        rowCount={rowCount}
+                        rows={gridRows}
                         sortModel={sortModel}
                         paginationMode={paginationMode}
                         sortingMode={sortAndFilterMode}
@@ -1501,7 +1485,7 @@ const GridBase = memo(({
                         columnHeaderHeight={columnHeaderHeight}
                         hideFooter={!showFooter}
                         rowGroupingModel={groupingModel}
-                        onRowGroupingModelChange={(newGroupingModel) => setGroupingModel(newGroupingModel)}
+                        onRowGroupingModelChange={setGroupingModel}
                         getRowClassName={props.getRowClassName}
                         columnGroupingModel={columnGroupingModel}
                     />


### PR DESCRIPTION
Add detail panel toggle positioning pinned to configured side when using per-row visibility control. Implement row selection normalization to convert 'exclude' type selections to 'include' for consistency. Add getSelectedRowIds callback to handle both 'include' and 'exclude' selection model types. Support configurable checkbox selection via model.checkboxSelection property. Update detail panel toggle column hiding to use data-field attribute selectors for improved targeting.