### PR TITLE
#67145: add responsive design to footer and gridProps support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@durlabh/dframework-ui",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "private": true,
   "type": "module",
   "main": "./index.js",

--- a/src/lib/components/Grid/footer.js
+++ b/src/lib/components/Grid/footer.js
@@ -52,13 +52,13 @@ const Footer = ({ pagination, apiRef, tTranslate = (key) => key, totalRowCount }
 
     return (
         <GridFooterContainer>
-            <Box sx={{ pl: 5 }}>
+            <Box sx={{ pl: { xs: 1, sm: 5 }, display: 'flex', alignItems: 'center' }}>
                 {pagination &&
                     <>
-                        <Typography variant="p">{tTranslate('Jump to page', tOpts)}:</Typography>
+                        <Typography variant="p" sx={{ whiteSpace: 'nowrap' }}>{tTranslate('Jump to page', tOpts)}:</Typography>
                         <TextField
                             sx={{
-                                width: 70,
+                                width: { xs: 35, sm: 60 },
                                 pl: 1,
                                 '& input[type=number]::-webkit-inner-spin-button': {
                                     cursor: 'pointer'

--- a/src/lib/components/Grid/footer.js
+++ b/src/lib/components/Grid/footer.js
@@ -55,7 +55,7 @@ const Footer = ({ pagination, apiRef, tTranslate = (key) => key, totalRowCount }
             <Box sx={{ pl: { xs: 1, sm: 5 }, display: 'flex', alignItems: 'center' }}>
                 {pagination &&
                     <>
-                        <Typography variant="p" sx={{ whiteSpace: 'nowrap' }}>{tTranslate('Jump to page', tOpts)}:</Typography>
+                        <Typography variant="body2" sx={{ whiteSpace: 'nowrap' }}>{tTranslate('Jump to page', tOpts)}:</Typography>
                         <TextField
                             sx={{
                                 width: { xs: 35, sm: 60 },

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -1436,8 +1436,8 @@ const GridBase = memo(({
             <Box style={gridStyle || customStyle}>
                 <Box sx={{ display: 'flex', maxHeight: '80vh', flexDirection: 'column' }}>
                     <DataGridPremium
-                        sx={gridSxProps}
                         {...gridProps}
+                        sx={gridSxProps}
                         headerFilters={showHeaderFilters}
                         unstable_headerFilters={showHeaderFilters} //for older versions of mui
                         checkboxSelection={forAssignment || !!model.checkboxSelection}

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -204,6 +204,7 @@ const GridBase = memo(({
     baseFilters,
     customExportOptions,
     sx: propsSx,
+    gridProps,
     ...props
 }) => {
     const staticDataSource = props.staticData ?? model.staticData;
@@ -1488,6 +1489,7 @@ const GridBase = memo(({
                         onRowGroupingModelChange={setGroupingModel}
                         getRowClassName={props.getRowClassName}
                         columnGroupingModel={columnGroupingModel}
+                        {...gridProps}
                     />
                 </Box>
                 {errorMessage && (<DialogComponent open={!!errorMessage} onConfirm={clearError} onCancel={clearError} title="Info" hideCancelButton={true} > {errorMessage}</DialogComponent>)

--- a/src/lib/components/Grid/index.js
+++ b/src/lib/components/Grid/index.js
@@ -1437,6 +1437,7 @@ const GridBase = memo(({
                 <Box sx={{ display: 'flex', maxHeight: '80vh', flexDirection: 'column' }}>
                     <DataGridPremium
                         sx={gridSxProps}
+                        {...gridProps}
                         headerFilters={showHeaderFilters}
                         unstable_headerFilters={showHeaderFilters} //for older versions of mui
                         checkboxSelection={forAssignment || !!model.checkboxSelection}
@@ -1489,7 +1490,6 @@ const GridBase = memo(({
                         onRowGroupingModelChange={setGroupingModel}
                         getRowClassName={props.getRowClassName}
                         columnGroupingModel={columnGroupingModel}
-                        {...gridProps}
                     />
                 </Box>
                 {errorMessage && (<DialogComponent open={!!errorMessage} onConfirm={clearError} onCancel={clearError} title="Info" hideCancelButton={true} > {errorMessage}</DialogComponent>)


### PR DESCRIPTION
Add responsive styling to Grid footer component for mobile and tablet layouts:
- Update Box container with responsive padding (xs: 1, sm: 5) and flexbox alignment
- Add whiteSpace: nowrap to footer label to prevent text wrapping
- Make TextField width responsive (xs: 35, sm: 60) for smaller screens

Add gridProps parameter to GridBase component to forward additional grid configuration properties to the underlying Data Grid.

Bump version to 2.0.23.