### PR TITLE
Fix select field onChange order so custom field overrides are not lost

### DIFF
--- a/src/lib/components/Form/fields/select.js
+++ b/src/lib/components/Form/fields/select.js
@@ -54,10 +54,10 @@ const SelectField = React.memo(({ column, field, formik, lookups, dependsOn = []
     }, [formik.values[field], options, column.multiSelect, field]);
 
     const handleChange = useCallback((event) => {
+        formik.handleChange(event);
         if (typeof column.onChange === 'function') {
             column.onChange({ formik, value: event.target.value, options, event , t: tTranslate, tOpts});
         }
-        formik.handleChange(event);
         userSelected.current = true;
     }, [formik.values[field], column.onChange, options]);
 


### PR DESCRIPTION
- In Form/fields/select.js, the handleChange function was calling column.onChange first and then formik.handleChange. Any setFieldValue call inside column.onChange (e.g. to reject or clear an invalid selection) was immediately overridden by the subsequent formik.handleChange, so the override never took effect.
- Swapped the execution order so formik.handleChange runs first to commit the selected value, then column.onChange fires and can inspect or override it via setFieldValue.